### PR TITLE
Update GoTrue to the latest version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(name: "GoTrue", url: "https://github.com/supabase/gotrue-swift.git", .exact("0.0.2")),
+    .package(name: "GoTrue", url: "https://github.com/supabase/gotrue-swift.git", .exact("0.0.3")),
     .package(
       name: "SupabaseStorage", url: "https://github.com/supabase/storage-swift.git", .exact("0.0.1")
     ),


### PR DESCRIPTION
There are some errors on registration so it would be great if we update GoTrue to the latest version. In the latest version this problem seems to be fixed.