### PR TITLE
Fixed README code example typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you're using Xcode, [use this guide](https://developer.apple.com/documentatio
 For all requests made for supabase, you will need to initialize a `SupabaseClient` object.
 
 ```swift
-let client = SupabaseClient(supabaseUrl: "{ Supabase URL }", supabaseKey: "{ Supabase anonymous Key }")
+let client = SupabaseClient(supabaseURL: "{ Supabase URL }", supabaseKey: "{ Supabase anonymous Key }")
 ```
 
 ## Contributing


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fixes typo in README code example.

## What is the current behaviour?
The example shows one of the required client arguments as `supabaseUrl`, but swift is case-sensitive and this throws an error, it should be `supabaseURL`.

## What is the new behavior?
Fixed typo, error no longer shows when following example.

## Additional context
<img width="1597" alt="Screenshot 2022-10-21 at 12 28 33 pm" src="https://user-images.githubusercontent.com/66140148/197185825-f4ace56c-628f-4f90-8ac5-f68d3f7285a1.png">
