### PR TITLE
Ignore error on refreshing current session

### DIFF
--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -111,7 +111,7 @@ public class SupabaseClient {
 
 extension SupabaseClient {
   func adapt(request: URLRequest) async throws -> URLRequest {
-    try await auth.refreshCurrentSessionIfNeeded()
+    try? await auth.refreshCurrentSessionIfNeeded()
 
     var request = request
     if let accessToken = auth.session?.accessToken {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Ignore `SessionNotFound` error on "refresh session if needed"

## What is the current behavior?

`gotrue-swift` throws and `SessionNotFound` when session is not found.

## What is the new behavior?

Supabase supports tables without RLS and requests to public tables without an auth session. Old behaviour prevents user to request data from database without having a valid auth session.

New behaviour will continue running the request with the application API key.


## Additional context

Populate an empty Supabase project with the `Countries` quick start script and request data from that table:

```
let countryQuery = client.database.from("countries").select()
let countryResponse = try await countryQuery.execute()

if let data = try? countryResponse.decoded(to: [Country].self) {
    countries = data
}
```
