### PR TITLE
Fix functions URL

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,7 @@ let package = Package(
         .product(name: "PostgREST", package: "postgrest-swift"),
         .product(name: "Functions", package: "functions-swift"),
       ]
-    )
+    ),
+    .testTarget(name: "SupabaseTests", dependencies: ["Supabase"]),
   ]
 )

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -11,6 +11,7 @@ public class SupabaseClient {
   private let supabaseURL: URL
   private let supabaseKey: String
   private let schema: String
+  private let functionsURL: URL
 
   /// Supabase Auth allows you to create and manage user sessions for access to data that is secured
   /// by access policies.
@@ -46,7 +47,7 @@ public class SupabaseClient {
   /// Supabase Functions allows you to deploy and invoke edge functions.
   public var functions: FunctionsClient {
     FunctionsClient(
-      url: supabaseURL.appendingPathComponent("/functions/v1"),
+      url: functionsURL,
       headers: defaultHeaders,
       apiClientDelegate: self
     )
@@ -81,6 +82,16 @@ public class SupabaseClient {
       url: supabaseURL.appendingPathComponent("/auth/v1"),
       headers: defaultHeaders
     )
+
+    let isPlatform =
+      supabaseURL.absoluteString.contains("supabase.co")
+      || supabaseURL.absoluteString.contains("supabase.in")
+    if isPlatform {
+      let urlParts = supabaseURL.absoluteString.split(separator: ".")
+      functionsURL = URL(string: "\(urlParts[0]).functions.\(urlParts[1]).\(urlParts[2])")!
+    } else {
+      functionsURL = supabaseURL.appendingPathComponent("functions/v1")
+    }
   }
 
   public struct HTTPClient {

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -11,7 +11,8 @@ public class SupabaseClient {
   private let supabaseURL: URL
   private let supabaseKey: String
   private let schema: String
-  private let functionsURL: URL
+
+  let functionsURL: URL
 
   /// Supabase Auth allows you to create and manage user sessions for access to data that is secured
   /// by access policies.

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import Supabase
+
+final class SupabaseClientTests: XCTestCase {
+  func testFunctionsURL() {
+    var client = SupabaseClient(supabaseURL: URL(string: "https://project-ref.supabase.co")!, supabaseKey: "ANON_KEY")
+    XCTAssertEqual(client.functionsURL.absoluteString, "https://project-ref.functions.supabase.co")
+
+    client = SupabaseClient(supabaseURL: URL(string: "https://project-ref.supabase.in")!, supabaseKey: "ANON_KEY")
+    XCTAssertEqual(client.functionsURL.absoluteString, "https://project-ref.functions.supabase.in")
+
+    client = SupabaseClient(supabaseURL: URL(string: "https://custom-domain.com")!, supabaseKey: "ANON_KEY")
+    XCTAssertEqual(client.functionsURL.absoluteString, "https://custom-domain.com/functions/v1")
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #58 

## What is the current behavior?

A wrong functions URL was used for initializing the `FunctionsClient`.

## What is the new behavior?

Check if the Supabase URL contains `supabase.co` or `supabase.in`, and create the functions URL based on it.
