### PR TITLE
Updated Readme with Login/Signup Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,146 @@ For all requests made for supabase, you will need to initialize a `SupabaseClien
 let client = SupabaseClient(supabaseURL: "{ Supabase URL }", supabaseKey: "{ Supabase anonymous Key }")
 ```
 
+## Login Implementation
+
+Import and Initialize GoTrueSwift which is bundled with Supabase Swift
+```swift
+import GoTrue
+
+//Intialize Gotrue
+var client: GoTrueClient = GoTrueClient(url: "{ Supabase URL }", headers: ["apikey": { Supabase anonymous Key }])
+```
+
+Here's how to Sign Up with Email and get the signed in users Session Info.
+
+```swift
+Task {
+  do {
+      try await client.signUp(email: email, password: password)
+      let session = try await client.session
+      print("### Session Info: \(session)") 
+  } catch {
+      print("### Sign Up Error: \(error)")
+  }
+}
+```
+
+Here's how to Login with Email for an existing users and get the logged in users Session Info.
+
+```swift
+Task {
+  do {
+      try await client.signIn(email: email, password: password)
+      let session = try await client.session
+      print("### Session Info: \(session)") 
+  } catch {
+      print("### Sign Up Error: \(error)")
+  }
+}
+```
+
+## Social Login Implementation
+
+### Setup Callback URL
+
+We need to first setup the callback URL for all Social Logins inside the app.
+
+- Setup the callback URL on Info.plist
+```xml
+<array>
+    <dict>
+        <key>CFBundleTypeRole</key>
+        <string>Editor</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+            <string>app.yourapp://login-callback</string>
+        </array>
+    </dict>
+</array>
+```
+- Add this callback URL on Supabase under Authentication -> URL Configuration -> Redirect URLs
+
+### Google Sign In
+
+- Setup Google Auth as per [Supabase's Documentation](https://supabase.com/docs/guides/auth/social-login/auth-google)
+- Note: For iOS we still need to use Google Consent Form for Web
+- Import SafariServices to your ViewController and create a SafariVC instance
+
+```swift
+import SafariServices
+
+var safariVC: SFSafariViewController?
+```
+- Get the URL for Google Sign in from Supabase and load it on SFSafariViewController
+- Add the previous callback URL you set up in the redirecTo
+
+```swift
+Task {
+    do {
+        let url = try await client.getOAuthSignInURL(provider: Provider.google, redirectTo: URL(string: {Your Callback URL})!)
+        safariVC = SFSafariViewController(url: url as URL)
+        self.present(safariVC!, animated: true, completion: nil)
+    } catch {
+        print("### Google Sign in Error: \(error)")
+    }
+}
+```
+- Handle the callback URL on SceneDelegate. (For older projects you can use AppDelegate if SceneDelegate is not there in the project)
+- Post NotificationCenter call to let the View Controller know that callback has been received and pass the URL received. This URL will be used to get the session for the user
+```swift
+func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    if let url = URLContexts.first?.url as? URL {
+        if url.host == "login-callback" {
+            let urlDict: [String: URL] = ["url": url]
+            NotificationCenter.default.post(name: Notification.Name("OAuthCallBack"), object: nil, userInfo: urlDict)
+        }
+    }
+}
+```
+- In your View Controller observe for the Notification and handle minimizing the SFSafariViewController and get the session
+```swift
+NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.oAuthCallback(_:)),
+            name: NSNotification.Name(rawValue: "OAuthCallBack"),
+            object: nil)
+            
+@objc func oAuthCallback(_ notification: NSNotification){
+    guard let url = notification.userInfo?["url"] as? URL  else { return }
+    Task {
+        do {
+            let session = try await SupaBaseAuth().client.session(from: url)
+            print("### Session Info: \(session)")
+        } catch {
+            print("### oAuthCallback error: \(error)")
+        }
+    }
+    safariVC?.dismiss(animated: true)
+}
+```
+
+### Apple Sign In
+
+- Setup Apple Auth as per [Supabase's Documentation](https://supabase.com/docs/guides/auth/social-login/auth-apple) 
+- For Sign in with Apple follow the above as per Google Sign In and just replace the provider
+- Once the user moves to the SFSafariViewController the Apple Native Popup will slide up to continue with Sign In.
+
+```swift
+Task {
+    do {
+        let url = try await client.getOAuthSignInURL(provider: **Provider.apple**, redirectTo: URL(string: {Your Callback URL})!)
+        safariVC = SFSafariViewController(url: url as URL)
+        self.present(safariVC!, animated: true, completion: nil)
+    } catch {
+        print("### Apple Sign in Error: \(error)")
+    }
+}
+```
+
+### Other Social Logins
+
+- Other Social Logins if using a webview will be similar to above and just follow the [Supabase's Documentation](https://supabase.com/docs/guides/auth/) for their setup
+
 ## Contributing
 
 - Fork the repo on GitHub


### PR DESCRIPTION
Added Basic Login implementation and some Social Login Implementation for Swift using UIKit

## What kind of change does this PR introduce?

Update to the ReadMe

## What is the current behavior?

The current Read Me does not include examples for login and social login

## What is the new behavior?

Added examples for the login and social logins

## Additional context

I believe this would be very helpful for people who want to get started with Supabase for iOS Projects.
