### PR TITLE
Adding an index to docs for ease of access

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 Supabase client for swift. Mirrors the design of [supabase-js](https://github.com/supabase/supabase-js/blob/master/README.md).
 
+## Contents
+- [Installation](#installation)
+- [Usage](#usage)
+- [Login Implementation](#login-implementation)
+- [Social Login Implementation](#social-login-implementation)
+    - [Setup Callback URL](#setup-callback-url)
+    - [Google Sign In](#google-sign-in)
+    - [Apple Sign In](#apple-sign-in)
+    - [Other Social Logins](#other-social-logins)
+- [Basic CRUD Implementation](#basic-crud-implementation)
+    - [Insert Data](#insert-data)
+    - [Select Data](#select-data)
+- [Contributing](#contributing)
+- [Sponsors](#sponsors)
+
+---
+
 ## Installation
 
 Swift Package Manager:


### PR DESCRIPTION
## What kind of change does this PR introduce?

- This PR adds a 'Contents' section to the README file.
- The contents section acts as an index with links to the respective sections.
- This should allow users to quickly jump to specific sections of the documentation as required.

## What is the current behavior?

- Currently the documentation does not have a contents section providing an overview of the docs.
- As the documentation grows, navigating it could become tedious.

## What is the new behavior?

- The changes allow to jump between sections through the links.

## Additional context

NA
