### PR TITLE
feat: edge functions support for custom domains and vanity domains

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/supabase-community/functions-swift",
       "state" : {
-        "revision" : "7d5dfce3673bb30bbb7e1fbb5e0afe01bbd92624",
-        "version" : "0.2.0"
+        "revision" : "c680cdfc53399376bdece299b1387b4fb3da514e",
+        "version" : "1.0.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/supabase-community/gotrue-swift",
       "state" : {
-        "revision" : "052fff22d1c2ffa4c3a6b3b58432e251f352891b",
-        "version" : "0.1.1"
+        "revision" : "a972c99bf0ed745047ec7bc6231460f6738d004e",
+        "version" : "1.1.1"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/supabase-community/storage-swift.git",
       "state" : {
-        "revision" : "04703e499ca258899d7ad45717efe75b8ddc09ab",
-        "version" : "0.1.0"
+        "revision" : "db67ce7764ef80e7941cea6bc4a0104c88e060f8",
+        "version" : "0.1.3"
       }
     },
     {

--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -72,6 +72,7 @@ public class SupabaseClient {
     storageURL = supabaseURL.appendingPathComponent("/storage/v1")
     databaseURL = supabaseURL.appendingPathComponent("/rest/v1")
     realtimeURL = supabaseURL.appendingPathComponent("/realtime/v1")
+    functionsURL = supabaseURL.appendingPathComponent("/functions/v1")
 
     schema = options.db.schema
     httpClient = options.global.httpClient
@@ -86,16 +87,6 @@ public class SupabaseClient {
       headers: defaultHeaders,
       localStorage: options.auth.storage
     )
-
-    let isPlatform =
-      supabaseURL.absoluteString.contains("supabase.co")
-        || supabaseURL.absoluteString.contains("supabase.in")
-    if isPlatform {
-      let urlParts = supabaseURL.absoluteString.split(separator: ".")
-      functionsURL = URL(string: "\(urlParts[0]).functions.\(urlParts[1]).\(urlParts[2])")!
-    } else {
-      functionsURL = supabaseURL.appendingPathComponent("functions/v1")
-    }
   }
 
   public struct HTTPClient {

--- a/Tests/SupabaseTests/SupabaseClientTests.swift
+++ b/Tests/SupabaseTests/SupabaseClientTests.swift
@@ -38,6 +38,8 @@ final class SupabaseClientTests: XCTestCase {
     XCTAssertEqual(client.storageURL.absoluteString, "https://project-ref.supabase.co/storage/v1")
     XCTAssertEqual(client.databaseURL.absoluteString, "https://project-ref.supabase.co/rest/v1")
     XCTAssertEqual(client.realtimeURL.absoluteString, "https://project-ref.supabase.co/realtime/v1")
+    XCTAssertEqual(client.functionsURL.absoluteString, "https://project-ref.supabase.co/functions/v1")
+
     XCTAssertEqual(
       client.defaultHeaders,
       [
@@ -46,25 +48,5 @@ final class SupabaseClientTests: XCTestCase {
         "header_field": "header_value",
       ]
     )
-  }
-
-  func testFunctionsURL() {
-    var client = SupabaseClient(
-      supabaseURL: URL(string: "https://project-ref.supabase.co")!,
-      supabaseKey: "ANON_KEY"
-    )
-    XCTAssertEqual(client.functionsURL.absoluteString, "https://project-ref.functions.supabase.co")
-
-    client = SupabaseClient(
-      supabaseURL: URL(string: "https://project-ref.supabase.in")!,
-      supabaseKey: "ANON_KEY"
-    )
-    XCTAssertEqual(client.functionsURL.absoluteString, "https://project-ref.functions.supabase.in")
-
-    client = SupabaseClient(
-      supabaseURL: URL(string: "https://custom-domain.com")!,
-      supabaseKey: "ANON_KEY"
-    )
-    XCTAssertEqual(client.functionsURL.absoluteString, "https://custom-domain.com/functions/v1")
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Invoke functions with `/functions/v1` path prefix allowing us to support custom domains and vanity domains for edge functions
