### PR TITLE
refactor: share request logic between sub-packages

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Supabase.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Supabase.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1500"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/.swiftpm/xcode/xcshareddata/xcschemes/Supabase.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Supabase.xcscheme
@@ -27,78 +27,12 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "SupabaseTests"
-               BuildableName = "SupabaseTests"
-               BlueprintName = "SupabaseTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FunctionsTests"
-               BuildableName = "FunctionsTests"
-               BlueprintName = "FunctionsTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "GoTrueTests"
-               BuildableName = "GoTrueTests"
-               BlueprintName = "GoTrueTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "PostgRESTIntegrationTests"
-               BuildableName = "PostgRESTIntegrationTests"
-               BlueprintName = "PostgRESTIntegrationTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "PostgRESTTests"
-               BuildableName = "PostgRESTTests"
-               BlueprintName = "PostgRESTTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "RealtimeTests"
-               BuildableName = "RealtimeTests"
-               BlueprintName = "RealtimeTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "StorageTests"
-               BuildableName = "StorageTests"
-               BlueprintName = "StorageTests"
-               ReferencedContainer = "container:">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Supabase.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Examples/Examples/AuthView.swift
+++ b/Examples/Examples/AuthView.swift
@@ -21,12 +21,12 @@ final class AuthController: ObservableObject {
   }
 
   func observeAuth() async {
-    for await event in await supabase.auth.onAuthStateChange() {
+    for await (event, session) in await supabase.auth.onAuthStateChange() {
       guard event == .signedIn || event == .signedOut else {
         return
       }
 
-      session = try? await supabase.auth.session
+      self.session = session
     }
   }
 }

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -173,7 +173,10 @@ public actor GoTrueClient {
   /// Listen for auth state changes.
   ///
   /// An `.initialSession` is always emitted when this method is called.
-  public func onAuthStateChange() async -> AsyncStream<(event: AuthChangeEvent, session: Session?)> {
+  public func onAuthStateChange() async -> AsyncStream<(
+    event: AuthChangeEvent,
+    session: Session?
+  )> {
     let (id, stream) = await eventEmitter.attachListener()
 
     Task { [id] in

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -204,7 +204,7 @@ public actor GoTrueClient {
     return try await _signUp(
       request: .init(
         path: "/signup",
-        method: "POST",
+        method: .post,
         query: [
           redirectTo.map { URLQueryItem(name: "redirect_to", value: $0.absoluteString) },
         ].compactMap { $0 },
@@ -237,7 +237,7 @@ public actor GoTrueClient {
     try await _signUp(
       request: .init(
         path: "/signup",
-        method: "POST",
+        method: .post,
         body: configuration.encoder.encode(
           SignUpRequest(
             password: password,
@@ -271,7 +271,7 @@ public actor GoTrueClient {
     try await _signIn(
       request: .init(
         path: "/token",
-        method: "POST",
+        method: .post,
         query: [URLQueryItem(name: "grant_type", value: "password")],
         body: configuration.encoder.encode(
           UserCredentials(email: email, password: password)
@@ -286,7 +286,7 @@ public actor GoTrueClient {
     try await _signIn(
       request: .init(
         path: "/token",
-        method: "POST",
+        method: .post,
         query: [URLQueryItem(name: "grant_type", value: "password")],
         body: configuration.encoder.encode(
           UserCredentials(password: password, phone: phone)
@@ -302,7 +302,7 @@ public actor GoTrueClient {
     try await _signIn(
       request: .init(
         path: "/token",
-        method: "POST",
+        method: .post,
         query: [URLQueryItem(name: "grant_type", value: "id_token")],
         body: configuration.encoder.encode(credentials)
       )
@@ -350,7 +350,7 @@ public actor GoTrueClient {
     try await api.execute(
       .init(
         path: "/otp",
-        method: "POST",
+        method: .post,
         query: [
           redirectTo.map { URLQueryItem(name: "redirect_to", value: $0.absoluteString) },
         ].compactMap { $0 },
@@ -385,7 +385,7 @@ public actor GoTrueClient {
     try await api.execute(
       .init(
         path: "/otp",
-        method: "POST",
+        method: .post,
         body: configuration.encoder.encode(
           OTPParams(
             phone: phone,
@@ -407,7 +407,7 @@ public actor GoTrueClient {
       let session: Session = try await api.execute(
         .init(
           path: "/token",
-          method: "POST",
+          method: .post,
           query: [URLQueryItem(name: "grant_type", value: "pkce")],
           body: configuration.encoder.encode(
             [
@@ -519,7 +519,7 @@ public actor GoTrueClient {
     let user = try await api.execute(
       .init(
         path: "/user",
-        method: "GET",
+        method: .get,
         headers: ["Authorization": "\(tokenType) \(accessToken)"]
       )
     ).decoded(as: User.self, decoder: configuration.decoder)
@@ -593,7 +593,7 @@ public actor GoTrueClient {
       try await api.authorizedExecute(
         .init(
           path: "/logout",
-          method: "POST"
+          method: .post
         )
       )
       await sessionManager.remove()
@@ -616,7 +616,7 @@ public actor GoTrueClient {
     try await _verifyOTP(
       request: .init(
         path: "/verify",
-        method: "POST",
+        method: .post,
         query: [
           redirectTo.map { URLQueryItem(name: "redirect_to", value: $0.absoluteString) },
         ].compactMap { $0 },
@@ -644,7 +644,7 @@ public actor GoTrueClient {
     try await _verifyOTP(
       request: .init(
         path: "/verify",
-        method: "POST",
+        method: .post,
         body: configuration.encoder.encode(
           VerifyOTPParams(
             phone: phone,
@@ -686,7 +686,7 @@ public actor GoTrueClient {
   /// Should be used only when you require the most current user data. For faster results,
   /// session.user is recommended.
   public func user(jwt: String? = nil) async throws -> User {
-    var request = Request(path: "/user", method: "GET")
+    var request = Request(path: "/user", method: .get)
 
     if let jwt {
       request.headers["Authorization"] = "Bearer \(jwt)"
@@ -709,7 +709,7 @@ public actor GoTrueClient {
 
     var session = try await sessionManager.session()
     let updatedUser = try await api.authorizedExecute(
-      .init(path: "/user", method: "PUT", body: configuration.encoder.encode(user))
+      .init(path: "/user", method: .put, body: configuration.encoder.encode(user))
     ).decoded(as: User.self, decoder: configuration.decoder)
     session.user = updatedUser
     try await sessionManager.update(session)
@@ -728,7 +728,7 @@ public actor GoTrueClient {
     try await api.execute(
       .init(
         path: "/recover",
-        method: "POST",
+        method: .post,
         query: [
           redirectTo.map { URLQueryItem(name: "redirect_to", value: $0.absoluteString) },
         ].compactMap { $0 },
@@ -759,7 +759,7 @@ public actor GoTrueClient {
     let session = try await api.execute(
       .init(
         path: "/token",
-        method: "POST",
+        method: .post,
         query: [URLQueryItem(name: "grant_type", value: "refresh_token")],
         body: configuration.encoder.encode(credentials)
       )

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -130,7 +130,7 @@ public actor GoTrueClient {
   /// - Parameters:
   ///   - configuration: The client configuration.
   public init(configuration: Configuration) {
-    let api = APIClient()
+    let api = APIClient(http: HTTPClient(fetchHandler: configuration.fetch))
 
     self.init(
       configuration: configuration,

--- a/Sources/GoTrue/GoTrueMFA.swift
+++ b/Sources/GoTrue/GoTrueMFA.swift
@@ -33,7 +33,7 @@ public actor GoTrueMFA {
   public func enroll(params: MFAEnrollParams) async throws -> AuthMFAEnrollResponse {
     try await api.authorizedExecute(
       Request(
-        path: "/factors", method: "POST",
+        path: "/factors", method: .post,
         body: configuration.encoder.encode(params)
       )
     )
@@ -46,7 +46,7 @@ public actor GoTrueMFA {
   /// - Returns: An authentication response with the challenge information.
   public func challenge(params: MFAChallengeParams) async throws -> AuthMFAChallengeResponse {
     try await api.authorizedExecute(
-      Request(path: "/factors/\(params.factorId)/challenge", method: "POST")
+      Request(path: "/factors/\(params.factorId)/challenge", method: .post)
     )
     .decoded(decoder: configuration.decoder)
   }
@@ -59,7 +59,7 @@ public actor GoTrueMFA {
   public func verify(params: MFAVerifyParams) async throws -> AuthMFAVerifyResponse {
     let response: AuthMFAVerifyResponse = try await api.authorizedExecute(
       Request(
-        path: "/factors/\(params.factorId)/verify", method: "POST",
+        path: "/factors/\(params.factorId)/verify", method: .post,
         body: configuration.encoder.encode(params)
       )
     ).decoded(decoder: configuration.decoder)
@@ -79,7 +79,7 @@ public actor GoTrueMFA {
   @discardableResult
   public func unenroll(params: MFAUnenrollParams) async throws -> AuthMFAUnenrollResponse {
     try await api.authorizedExecute(
-      Request(path: "/factors/\(params.factorId)", method: "DELETE")
+      Request(path: "/factors/\(params.factorId)", method: .delete)
     )
     .decoded(decoder: configuration.decoder)
   }

--- a/Sources/GoTrue/Internal/EventEmitter.swift
+++ b/Sources/GoTrue/Internal/EventEmitter.swift
@@ -2,7 +2,10 @@ import Foundation
 @_spi(Internal) import _Helpers
 
 struct EventEmitter: Sendable {
-  var attachListener: @Sendable () async -> (id: UUID, stream: AsyncStream<(event: AuthChangeEvent, session: Session?)>)
+  var attachListener: @Sendable () async -> (
+    id: UUID,
+    stream: AsyncStream<(event: AuthChangeEvent, session: Session?)>
+  )
   var emit: @Sendable (_ event: AuthChangeEvent, _ session: Session?, _ id: UUID?) async -> Void
 }
 
@@ -14,13 +17,15 @@ extension EventEmitter {
 
 extension EventEmitter {
   static var live: Self = {
-    let continuations = ActorIsolated([UUID: AsyncStream<(event: AuthChangeEvent, session: Session?)>.Continuation]())
+    let continuations =
+      ActorIsolated([UUID: AsyncStream<(event: AuthChangeEvent, session: Session?)>.Continuation]())
 
     return Self(
       attachListener: {
         let id = UUID()
 
-        let (stream, continuation) = AsyncStream<(event: AuthChangeEvent, session: Session?)>.makeStream()
+        let (stream, continuation) = AsyncStream<(event: AuthChangeEvent, session: Session?)>
+          .makeStream()
 
         continuation.onTermination = { [id] _ in
           continuations.withValue {

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -102,7 +102,7 @@ public actor PostgrestClient {
   public func from(_ table: String) -> PostgrestQueryBuilder {
     PostgrestQueryBuilder(
       configuration: configuration,
-      request: .init(path: table, method: "GET", headers: configuration.headers)
+      request: .init(path: table, method: .get, headers: configuration.headers)
     )
   }
 
@@ -121,7 +121,7 @@ public actor PostgrestClient {
   ) throws -> PostgrestTransformBuilder {
     try PostgrestRpcBuilder(
       configuration: configuration,
-      request: Request(path: "/rpc/\(fn)", method: "POST", headers: configuration.headers)
+      request: Request(path: "/rpc/\(fn)", method: .post, headers: configuration.headers)
     ).rpc(params: params, count: count)
   }
 

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -102,11 +102,7 @@ public actor PostgrestClient {
   public func from(_ table: String) -> PostgrestQueryBuilder {
     PostgrestQueryBuilder(
       configuration: configuration,
-      url: configuration.url.appendingPathComponent(table),
-      queryParams: [],
-      headers: configuration.headers,
-      method: "GET",
-      body: nil
+      request: .init(path: table, method: "GET", headers: configuration.headers)
     )
   }
 
@@ -125,11 +121,7 @@ public actor PostgrestClient {
   ) throws -> PostgrestTransformBuilder {
     try PostgrestRpcBuilder(
       configuration: configuration,
-      url: configuration.url.appendingPathComponent("rpc").appendingPathComponent(fn),
-      queryParams: [],
-      headers: configuration.headers,
-      method: "POST",
-      body: nil
+      request: Request(path: "/rpc/\(fn)", method: "POST", headers: configuration.headers)
     ).rpc(params: params, count: count)
   }
 

--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -1,4 +1,5 @@
 import Foundation
+@_spi(Internal) import _Helpers
 
 public class PostgrestFilterBuilder: PostgrestTransformBuilder {
   public enum Operator: String, CaseIterable {
@@ -11,156 +12,236 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder {
   public func not(column: String, operator op: Operator, value: URLQueryRepresentable)
     -> PostgrestFilterBuilder
   {
-    appendSearchParams(name: column, value: "not.\(op.rawValue).\(value.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(
+        name: column,
+        value: "not.\(op.rawValue).\(value.queryValue)"
+      ))
+    }
+
     return self
   }
 
   public func or(filters: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: "or", value: "(\(filters.queryValue.queryValue))")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: "or", value: "(\(filters.queryValue.queryValue))"))
+    }
     return self
   }
 
   public func eq(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "eq.\(value.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "eq.\(value.queryValue)"))
+    }
     return self
   }
 
   public func neq(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "neq.\(value.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "neq.\(value.queryValue)"))
+    }
     return self
   }
 
   public func gt(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "gt.\(value.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "gt.\(value.queryValue)"))
+    }
     return self
   }
 
   public func gte(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "gte.\(value.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "gte.\(value.queryValue)"))
+    }
     return self
   }
 
   public func lt(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "lt.\(value.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "lt.\(value.queryValue)"))
+    }
     return self
   }
 
   public func lte(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "lte.\(value.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "lte.\(value.queryValue)"))
+    }
     return self
   }
 
   public func like(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "like.\(value.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "like.\(value.queryValue)"))
+    }
     return self
   }
 
   public func ilike(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "ilike.\(value.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "ilike.\(value.queryValue)"))
+    }
     return self
   }
 
   public func `is`(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "is.\(value.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "is.\(value.queryValue)"))
+    }
     return self
   }
 
   public func `in`(column: String, value: [URLQueryRepresentable]) -> PostgrestFilterBuilder {
-    appendSearchParams(
-      name: column,
-      value: "in.(\(value.map(\.queryValue).joined(separator: ",")))"
-    )
+    mutableState.withValue {
+      $0.request.query.append(
+        URLQueryItem(
+          name: column,
+          value: "in.(\(value.map(\.queryValue).joined(separator: ",")))"
+        )
+      )
+    }
     return self
   }
 
   public func contains(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "cs.\(value.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "cs.\(value.queryValue)"))
+    }
     return self
   }
 
   public func rangeLt(column: String, range: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "sl.\(range.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "sl.\(range.queryValue)"))
+    }
     return self
   }
 
   public func rangeGt(column: String, range: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "sr.\(range.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "sr.\(range.queryValue)"))
+    }
     return self
   }
 
   public func rangeGte(column: String, range: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "nxl.\(range.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "nxl.\(range.queryValue)"))
+    }
     return self
   }
 
   public func rangeLte(column: String, range: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "nxr.\(range.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "nxr.\(range.queryValue)"))
+    }
     return self
   }
 
   public func rangeAdjacent(column: String, range: URLQueryRepresentable) -> PostgrestFilterBuilder
   {
-    appendSearchParams(name: column, value: "adj.\(range.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "adj.\(range.queryValue)"))
+    }
     return self
   }
 
   public func overlaps(column: String, value: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "ov.\(value.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "ov.\(value.queryValue)"))
+    }
     return self
   }
 
   public func textSearch(column: String, range: URLQueryRepresentable) -> PostgrestFilterBuilder {
-    appendSearchParams(name: column, value: "adj.\(range.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: column, value: "adj.\(range.queryValue)"))
+    }
     return self
   }
 
   public func textSearch(
     column: String, query: URLQueryRepresentable, config: String? = nil, type: TextSearchType? = nil
   ) -> PostgrestFilterBuilder {
-    appendSearchParams(
-      name: column, value: "\(type?.rawValue ?? "")fts\(config ?? "").\(query.queryValue)"
-    )
+    mutableState.withValue {
+      $0.request.query.append(
+        URLQueryItem(
+          name: column, value: "\(type?.rawValue ?? "")fts\(config ?? "").\(query.queryValue)"
+        )
+      )
+    }
     return self
   }
 
   public func fts(column: String, query: URLQueryRepresentable, config: String? = nil)
     -> PostgrestFilterBuilder
   {
-    appendSearchParams(name: column, value: "fts\(config ?? "").\(query.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(
+        name: column,
+        value: "fts\(config ?? "").\(query.queryValue)"
+      ))
+    }
     return self
   }
 
   public func plfts(column: String, query: URLQueryRepresentable, config: String? = nil)
     -> PostgrestFilterBuilder
   {
-    appendSearchParams(name: column, value: "plfts\(config ?? "").\(query.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(
+        name: column,
+        value: "plfts\(config ?? "").\(query.queryValue)"
+      ))
+    }
     return self
   }
 
   public func phfts(column: String, query: URLQueryRepresentable, config: String? = nil)
     -> PostgrestFilterBuilder
   {
-    appendSearchParams(name: column, value: "phfts\(config ?? "").\(query.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(
+        name: column,
+        value: "phfts\(config ?? "").\(query.queryValue)"
+      ))
+    }
     return self
   }
 
   public func wfts(column: String, query: URLQueryRepresentable, config: String? = nil)
     -> PostgrestFilterBuilder
   {
-    appendSearchParams(name: column, value: "wfts\(config ?? "").\(query.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(
+        name: column,
+        value: "wfts\(config ?? "").\(query.queryValue)"
+      ))
+    }
     return self
   }
 
   public func filter(column: String, operator: Operator, value: URLQueryRepresentable)
     -> PostgrestFilterBuilder
   {
-    appendSearchParams(name: column, value: "\(`operator`.rawValue).\(value.queryValue)")
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(
+        name: column,
+        value: "\(`operator`.rawValue).\(value.queryValue)"
+      ))
+    }
     return self
   }
 
   public func match(query: [String: URLQueryRepresentable]) -> PostgrestFilterBuilder {
-    query.forEach { key, value in
-      appendSearchParams(name: key, value: "eq.\(value.queryValue)")
+    mutableState.withValue { mutableState in
+      query.forEach { key, value in
+        mutableState.request.query.append(URLQueryItem(
+          name: key,
+          value: "eq.\(value.queryValue)"
+        ))
+      }
     }
     return self
   }

--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -14,7 +14,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
     count: CountOption? = nil
   ) -> PostgrestFilterBuilder {
     mutableState.withValue {
-      $0.request.method = "GET"
+      $0.request.method = .get
       // remove whitespaces except when quoted.
       var quoted = false
       let cleanedColumns = columns.compactMap { char -> String? in
@@ -34,7 +34,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
         $0.request.headers["Prefer"] = "count=\(count.rawValue)"
       }
       if head {
-        $0.request.method = "HEAD"
+        $0.request.method = .head
       }
     }
 
@@ -54,7 +54,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
     count: CountOption? = nil
   ) throws -> PostgrestFilterBuilder {
     try mutableState.withValue {
-      $0.request.method = "POST"
+      $0.request.method = .post
       var prefersHeaders: [String] = []
       if let returning {
         prefersHeaders.append("return=\(returning.rawValue)")
@@ -100,7 +100,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
     ignoreDuplicates: Bool = false
   ) throws -> PostgrestFilterBuilder {
     try mutableState.withValue {
-      $0.request.method = "POST"
+      $0.request.method = .post
       var prefersHeaders = [
         "resolution=\(ignoreDuplicates ? "ignore" : "merge")-duplicates",
         "return=\(returning.rawValue)",
@@ -135,7 +135,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
     count: CountOption? = nil
   ) throws -> PostgrestFilterBuilder {
     try mutableState.withValue {
-      $0.request.method = "PATCH"
+      $0.request.method = .patch
       var preferHeaders = ["return=\(returning.rawValue)"]
       $0.request.body = try configuration.encoder.encode(values)
       if let count {
@@ -161,7 +161,7 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
     count: CountOption? = nil
   ) -> PostgrestFilterBuilder {
     mutableState.withValue {
-      $0.request.method = "DELETE"
+      $0.request.method = .delete
       var preferHeaders = ["return=\(returning.rawValue)"]
       if let count {
         preferHeaders.append("count=\(count.rawValue)")

--- a/Sources/PostgREST/PostgrestQueryBuilder.swift
+++ b/Sources/PostgREST/PostgrestQueryBuilder.swift
@@ -1,4 +1,5 @@
 import Foundation
+@_spi(Internal) import _Helpers
 
 public final class PostgrestQueryBuilder: PostgrestBuilder {
   /// Performs a vertical filtering with SELECT.
@@ -12,26 +13,31 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
     head: Bool = false,
     count: CountOption? = nil
   ) -> PostgrestFilterBuilder {
-    method = "GET"
-    // remove whitespaces except when quoted.
-    var quoted = false
-    let cleanedColumns = columns.compactMap { char -> String? in
-      if char.isWhitespace, !quoted {
-        return nil
+    mutableState.withValue {
+      $0.request.method = "GET"
+      // remove whitespaces except when quoted.
+      var quoted = false
+      let cleanedColumns = columns.compactMap { char -> String? in
+        if char.isWhitespace, !quoted {
+          return nil
+        }
+        if char == "\"" {
+          quoted = !quoted
+        }
+        return String(char)
       }
-      if char == "\"" {
-        quoted = !quoted
+      .joined(separator: "")
+
+      $0.request.query.append(URLQueryItem(name: "select", value: cleanedColumns))
+
+      if let count {
+        $0.request.headers["Prefer"] = "count=\(count.rawValue)"
       }
-      return String(char)
+      if head {
+        $0.request.method = "HEAD"
+      }
     }
-    .joined(separator: "")
-    appendSearchParams(name: "select", value: cleanedColumns)
-    if let count {
-      headers["Prefer"] = "count=\(count.rawValue)"
-    }
-    if head {
-      method = "HEAD"
-    }
+
     return PostgrestFilterBuilder(self)
   }
 
@@ -47,30 +53,32 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
     returning: PostgrestReturningOptions? = nil,
     count: CountOption? = nil
   ) throws -> PostgrestFilterBuilder {
-    method = "POST"
-    var prefersHeaders: [String] = []
-    if let returning {
-      prefersHeaders.append("return=\(returning.rawValue)")
-    }
-    body = try configuration.encoder.encode(values)
-    if let count {
-      prefersHeaders.append("count=\(count.rawValue)")
-    }
-    if let prefer = headers["Prefer"] {
-      prefersHeaders.insert(prefer, at: 0)
-    }
-    if !prefersHeaders.isEmpty {
-      headers["Prefer"] = prefersHeaders.joined(separator: ",")
-    }
+    try mutableState.withValue {
+      $0.request.method = "POST"
+      var prefersHeaders: [String] = []
+      if let returning {
+        prefersHeaders.append("return=\(returning.rawValue)")
+      }
+      $0.request.body = try configuration.encoder.encode(values)
+      if let count {
+        prefersHeaders.append("count=\(count.rawValue)")
+      }
+      if let prefer = $0.request.headers["Prefer"] {
+        prefersHeaders.insert(prefer, at: 0)
+      }
+      if !prefersHeaders.isEmpty {
+        $0.request.headers["Prefer"] = prefersHeaders.joined(separator: ",")
+      }
 
-    // TODO: How to do this in Swift?
-    // if (Array.isArray(values)) {
-    //     const columns = values.reduce((acc, x) => acc.concat(Object.keys(x)), [] as string[])
-    //     if (columns.length > 0) {
-    //         const uniqueColumns = [...new Set(columns)].map((column) => `"${column}"`)
-    //         this.url.searchParams.set('columns', uniqueColumns.join(','))
-    //     }
-    // }
+      // TODO: How to do this in Swift?
+      // if (Array.isArray(values)) {
+      //     const columns = values.reduce((acc, x) => acc.concat(Object.keys(x)), [] as string[])
+      //     if (columns.length > 0) {
+      //         const uniqueColumns = [...new Set(columns)].map((column) => `"${column}"`)
+      //         this.url.searchParams.set('columns', uniqueColumns.join(','))
+      //     }
+      // }
+    }
 
     return PostgrestFilterBuilder(self)
   }
@@ -91,23 +99,25 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
     count: CountOption? = nil,
     ignoreDuplicates: Bool = false
   ) throws -> PostgrestFilterBuilder {
-    method = "POST"
-    var prefersHeaders = [
-      "resolution=\(ignoreDuplicates ? "ignore" : "merge")-duplicates",
-      "return=\(returning.rawValue)",
-    ]
-    if let onConflict {
-      appendSearchParams(name: "on_conflict", value: onConflict)
-    }
-    body = try configuration.encoder.encode(values)
-    if let count {
-      prefersHeaders.append("count=\(count.rawValue)")
-    }
-    if let prefer = headers["Prefer"] {
-      prefersHeaders.insert(prefer, at: 0)
-    }
-    if !prefersHeaders.isEmpty {
-      headers["Prefer"] = prefersHeaders.joined(separator: ",")
+    try mutableState.withValue {
+      $0.request.method = "POST"
+      var prefersHeaders = [
+        "resolution=\(ignoreDuplicates ? "ignore" : "merge")-duplicates",
+        "return=\(returning.rawValue)",
+      ]
+      if let onConflict {
+        $0.request.query.append(URLQueryItem(name: "on_conflict", value: onConflict))
+      }
+      $0.request.body = try configuration.encoder.encode(values)
+      if let count {
+        prefersHeaders.append("count=\(count.rawValue)")
+      }
+      if let prefer = $0.request.headers["Prefer"] {
+        prefersHeaders.insert(prefer, at: 0)
+      }
+      if !prefersHeaders.isEmpty {
+        $0.request.headers["Prefer"] = prefersHeaders.joined(separator: ",")
+      }
     }
     return PostgrestFilterBuilder(self)
   }
@@ -124,17 +134,19 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
     returning: PostgrestReturningOptions = .representation,
     count: CountOption? = nil
   ) throws -> PostgrestFilterBuilder {
-    method = "PATCH"
-    var preferHeaders = ["return=\(returning.rawValue)"]
-    body = try configuration.encoder.encode(values)
-    if let count {
-      preferHeaders.append("count=\(count.rawValue)")
-    }
-    if let prefer = headers["Prefer"] {
-      preferHeaders.insert(prefer, at: 0)
-    }
-    if !preferHeaders.isEmpty {
-      headers["Prefer"] = preferHeaders.joined(separator: ",")
+    try mutableState.withValue {
+      $0.request.method = "PATCH"
+      var preferHeaders = ["return=\(returning.rawValue)"]
+      $0.request.body = try configuration.encoder.encode(values)
+      if let count {
+        preferHeaders.append("count=\(count.rawValue)")
+      }
+      if let prefer = $0.request.headers["Prefer"] {
+        preferHeaders.insert(prefer, at: 0)
+      }
+      if !preferHeaders.isEmpty {
+        $0.request.headers["Prefer"] = preferHeaders.joined(separator: ",")
+      }
     }
     return PostgrestFilterBuilder(self)
   }
@@ -148,16 +160,18 @@ public final class PostgrestQueryBuilder: PostgrestBuilder {
     returning: PostgrestReturningOptions = .representation,
     count: CountOption? = nil
   ) -> PostgrestFilterBuilder {
-    method = "DELETE"
-    var preferHeaders = ["return=\(returning.rawValue)"]
-    if let count {
-      preferHeaders.append("count=\(count.rawValue)")
-    }
-    if let prefer = headers["Prefer"] {
-      preferHeaders.insert(prefer, at: 0)
-    }
-    if !preferHeaders.isEmpty {
-      headers["Prefer"] = preferHeaders.joined(separator: ",")
+    mutableState.withValue {
+      $0.request.method = "DELETE"
+      var preferHeaders = ["return=\(returning.rawValue)"]
+      if let count {
+        preferHeaders.append("count=\(count.rawValue)")
+      }
+      if let prefer = $0.request.headers["Prefer"] {
+        preferHeaders.insert(prefer, at: 0)
+      }
+      if !preferHeaders.isEmpty {
+        $0.request.headers["Prefer"] = preferHeaders.joined(separator: ",")
+      }
     }
     return PostgrestFilterBuilder(self)
   }

--- a/Sources/PostgREST/PostgrestRpcBuilder.swift
+++ b/Sources/PostgREST/PostgrestRpcBuilder.swift
@@ -1,4 +1,5 @@
 import Foundation
+@_spi(Internal) import _Helpers
 
 struct NoParams: Encodable {}
 
@@ -20,18 +21,20 @@ public final class PostgrestRpcBuilder: PostgrestBuilder {
     // https://github.com/supabase/postgrest-js/blob/master/src/lib/PostgrestRpcBuilder.ts#L38
     assert(head == false, "HEAD is not currently supported yet.")
 
-    method = "POST"
-    if params is NoParams {
-      // noop
-    } else {
-      body = try configuration.encoder.encode(params)
-    }
-
-    if let count {
-      if let prefer = headers["Prefer"] {
-        headers["Prefer"] = "\(prefer),count=\(count.rawValue)"
+    try mutableState.withValue {
+      $0.request.method = "POST"
+      if params is NoParams {
+        // noop
       } else {
-        headers["Prefer"] = "count=\(count.rawValue)"
+        $0.request.body = try configuration.encoder.encode(params)
+      }
+
+      if let count {
+        if let prefer = $0.request.headers["Prefer"] {
+          $0.request.headers["Prefer"] = "\(prefer),count=\(count.rawValue)"
+        } else {
+          $0.request.headers["Prefer"] = "count=\(count.rawValue)"
+        }
       }
     }
 

--- a/Sources/PostgREST/PostgrestRpcBuilder.swift
+++ b/Sources/PostgREST/PostgrestRpcBuilder.swift
@@ -22,7 +22,7 @@ public final class PostgrestRpcBuilder: PostgrestBuilder {
     assert(head == false, "HEAD is not currently supported yet.")
 
     try mutableState.withValue {
-      $0.request.method = "POST"
+      $0.request.method = .post
       if params is NoParams {
         // noop
       } else {

--- a/Sources/PostgREST/PostgrestTransformBuilder.swift
+++ b/Sources/PostgREST/PostgrestTransformBuilder.swift
@@ -1,3 +1,6 @@
+@_spi(Internal) import _Helpers
+import Foundation
+
 public class PostgrestTransformBuilder: PostgrestBuilder {
   /// Performs a vertical filtering with SELECT.
   /// - Parameters:
@@ -15,7 +18,9 @@ public class PostgrestTransformBuilder: PostgrestBuilder {
       return String(char)
     }
     .joined(separator: "")
-    appendSearchParams(name: "select", value: cleanedColumns)
+    mutableState.withValue {
+      $0.request.query.append(URLQueryItem(name: "select", value: cleanedColumns))
+    }
     return self
   }
 
@@ -31,16 +36,22 @@ public class PostgrestTransformBuilder: PostgrestBuilder {
     nullsFirst: Bool = false,
     foreignTable: String? = nil
   ) -> PostgrestTransformBuilder {
-    let key = foreignTable.map { "\($0).order" } ?? "order"
-    let existingOrderIndex = queryParams.firstIndex(where: { $0.name == key })
-    let value = "\(column).\(ascending ? "asc" : "desc").\(nullsFirst ? "nullsfirst" : "nullslast")"
+    mutableState.withValue {
+      let key = foreignTable.map { "\($0).order" } ?? "order"
+      let existingOrderIndex = $0.request.query.firstIndex { $0.name == key }
+      let value =
+        "\(column).\(ascending ? "asc" : "desc").\(nullsFirst ? "nullsfirst" : "nullslast")"
 
-    if let existingOrderIndex,
-       let currentValue = queryParams[existingOrderIndex].value
-    {
-      queryParams[existingOrderIndex] = (key, "\(currentValue),\(value)")
-    } else {
-      queryParams.append((key, value))
+      if let existingOrderIndex,
+         let currentValue = $0.request.query[existingOrderIndex].value
+      {
+        $0.request.query[existingOrderIndex] = URLQueryItem(
+          name: key,
+          value: "\(currentValue),\(value)"
+        )
+      } else {
+        $0.request.query.append(URLQueryItem(name: key, value: value))
+      }
     }
 
     return self
@@ -51,11 +62,13 @@ public class PostgrestTransformBuilder: PostgrestBuilder {
   ///   - count: The maximum no. of rows to limit to.
   ///   - foreignTable: The foreign table to use (for foreign columns).
   public func limit(count: Int, foreignTable: String? = nil) -> PostgrestTransformBuilder {
-    let key = foreignTable.map { "\($0).limit" } ?? "limit"
-    if let index = queryParams.firstIndex(where: { $0.name == key }) {
-      queryParams[index] = (key, "\(count)")
-    } else {
-      queryParams.append((key, "\(count)"))
+    mutableState.withValue {
+      let key = foreignTable.map { "\($0).limit" } ?? "limit"
+      if let index = $0.request.query.firstIndex(where: { $0.name == key }) {
+        $0.request.query[index] = URLQueryItem(name: key, value: "\(count)")
+      } else {
+        $0.request.query.append(URLQueryItem(name: key, value: "\(count)"))
+      }
     }
     return self
   }
@@ -63,7 +76,7 @@ public class PostgrestTransformBuilder: PostgrestBuilder {
   /// Limits the result to rows within the specified range, inclusive.
   /// - Parameters:
   ///   - lowerBounds: The starting index from which to limit the result, inclusive.
-  ///   - upperBounds: The last index to which to limit the result, inclusve.
+  ///   - upperBounds: The last index to which to limit the result, inclusive.
   ///   - foreignTable: The foreign table to use (for foreign columns).
   public func range(
     from lowerBounds: Int,
@@ -73,17 +86,25 @@ public class PostgrestTransformBuilder: PostgrestBuilder {
     let keyOffset = foreignTable.map { "\($0).offset" } ?? "offset"
     let keyLimit = foreignTable.map { "\($0).limit" } ?? "limit"
 
-    if let index = queryParams.firstIndex(where: { $0.name == keyOffset }) {
-      queryParams[index] = (keyOffset, "\(lowerBounds)")
-    } else {
-      queryParams.append((keyOffset, "\(lowerBounds)"))
-    }
+    mutableState.withValue {
+      if let index = $0.request.query.firstIndex(where: { $0.name == keyOffset }) {
+        $0.request.query[index] = URLQueryItem(name: keyOffset, value: "\(lowerBounds)")
+      } else {
+        $0.request.query.append(URLQueryItem(name: keyOffset, value: "\(lowerBounds)"))
+      }
 
-    // Range is inclusive, so add 1
-    if let index = queryParams.firstIndex(where: { $0.name == keyLimit }) {
-      queryParams[index] = (keyLimit, "\(upperBounds - lowerBounds + 1)")
-    } else {
-      queryParams.append((keyLimit, "\(upperBounds - lowerBounds + 1)"))
+      // Range is inclusive, so add 1
+      if let index = $0.request.query.firstIndex(where: { $0.name == keyLimit }) {
+        $0.request.query[index] = URLQueryItem(
+          name: keyLimit,
+          value: "\(upperBounds - lowerBounds + 1)"
+        )
+      } else {
+        $0.request.query.append(URLQueryItem(
+          name: keyLimit,
+          value: "\(upperBounds - lowerBounds + 1)"
+        ))
+      }
     }
 
     return self
@@ -92,13 +113,17 @@ public class PostgrestTransformBuilder: PostgrestBuilder {
   /// Retrieves only one row from the result. Result must be one row (e.g. using `limit`), otherwise
   /// this will result in an error.
   public func single() -> PostgrestTransformBuilder {
-    headers["Accept"] = "application/vnd.pgrst.object+json"
+    mutableState.withValue {
+      $0.request.headers["Accept"] = "application/vnd.pgrst.object+json"
+    }
     return self
   }
 
   /// Set the response type to CSV.
   public func csv() -> PostgrestTransformBuilder {
-    headers["Accept"] = "text/csv"
+    mutableState.withValue {
+      $0.request.headers["Accept"] = "text/csv"
+    }
     return self
   }
 }

--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct PostgrestError: Error, Codable {
+public struct PostgrestError: Error, Codable, Sendable {
   public let details: String?
   public let hint: String?
   public let code: String?
@@ -20,7 +20,7 @@ extension PostgrestError: LocalizedError {
   }
 }
 
-public struct PostgrestResponse<T> {
+public struct PostgrestResponse<T: Sendable>: Sendable {
   public let data: Data
   public let response: HTTPURLResponse
   public let count: Int?
@@ -51,7 +51,7 @@ public struct PostgrestResponse<T> {
 }
 
 /// Returns count as part of the response when specified.
-public enum CountOption: String {
+public enum CountOption: String, Sendable {
   case exact
   case planned
   case estimated
@@ -60,7 +60,7 @@ public enum CountOption: String {
 /// Enum of options representing the ways PostgREST can return values from the server.
 ///
 /// https://postgrest.org/en/v9.0/api.html?highlight=PREFER#insertions-updates
-public enum PostgrestReturningOptions: String {
+public enum PostgrestReturningOptions: String, Sendable {
   /// Returns nothing from the server
   case minimal
   /// Returns a copy of the updated data.
@@ -68,7 +68,7 @@ public enum PostgrestReturningOptions: String {
 }
 
 /// The type of tsquery conversion to use on query.
-public enum TextSearchType: String {
+public enum TextSearchType: String, Sendable {
   /// Uses PostgreSQL's plainto_tsquery function.
   case plain = "pl"
   /// Uses PostgreSQL's phraseto_tsquery function.
@@ -80,7 +80,7 @@ public enum TextSearchType: String {
 }
 
 /// Options for querying Supabase.
-public struct FetchOptions {
+public struct FetchOptions: Sendable {
   /// Set head to true if you only want the count value and not the underlying data.
   public let head: Bool
 

--- a/Sources/Realtime/RealtimeChannel.swift
+++ b/Sources/Realtime/RealtimeChannel.swift
@@ -740,7 +740,7 @@ public class RealtimeChannel {
       do {
         let request = try Request(
           path: "",
-          method: "POST",
+          method: .post,
           headers: headers.mapValues { "\($0)" },
           body: JSONSerialization.data(withJSONObject: body)
         )

--- a/Sources/Realtime/RealtimeChannel.swift
+++ b/Sources/Realtime/RealtimeChannel.swift
@@ -744,16 +744,12 @@ public class RealtimeChannel {
           headers: headers.mapValues { "\($0)" },
           body: JSONSerialization.data(withJSONObject: body)
         )
-        let urlRequest = try request.urlRequest(withBaseURL: broadcastEndpointURL)
-        let (_, response) = try await URLSession.shared.data(for: urlRequest)
-        guard let httpResponse = response as? HTTPURLResponse else {
+
+        let response = try await socket?.http.fetch(request, baseURL: broadcastEndpointURL)
+        guard let response, 200 ..< 300 ~= response.statusCode else {
           return .error
         }
-        if 200 ..< 300 ~= httpResponse.statusCode {
-          return .ok
-        }
-
-        return .error
+        return .ok
       } catch {
         return .error
       }

--- a/Sources/Realtime/RealtimeClient.swift
+++ b/Sources/Realtime/RealtimeClient.swift
@@ -166,6 +166,9 @@ public class RealtimeClient: PhoenixTransportDelegate {
   /// The connection to the server
   var connection: PhoenixTransport? = nil
 
+  /// The HTTPClient to perform HTTP requests.
+  let http: HTTPClient
+
   var accessToken: String?
 
   // ----------------------------------------------------------------------
@@ -222,6 +225,7 @@ public class RealtimeClient: PhoenixTransportDelegate {
       headers["X-Client-Info"] = "realtime-swift/\(version)"
     }
     self.headers = headers
+    http = HTTPClient(fetchHandler: { try await URLSession.shared.data(for: $0) })
 
     let params = paramsClosure?()
     if let jwt = (params?["Authorization"] as? String)?.split(separator: " ").last {

--- a/Sources/Storage/StorageApi.swift
+++ b/Sources/Storage/StorageApi.swift
@@ -5,7 +5,7 @@ import Foundation
   import FoundationNetworking
 #endif
 
-public class StorageApi {
+public class StorageApi: @unchecked Sendable {
   public let configuration: StorageClientConfiguration
 
   private let http: HTTPClient

--- a/Sources/Storage/StorageApi.swift
+++ b/Sources/Storage/StorageApi.swift
@@ -38,7 +38,7 @@ public class StorageApi {
 
 extension Request {
   init(
-    path: String, method: String, formData: FormData, options: FileOptions,
+    path: String, method: Method, formData: FormData, options: FileOptions,
     headers: [String: String] = [:]
   ) {
     var headers = headers

--- a/Sources/Storage/StorageBucketApi.swift
+++ b/Sources/Storage/StorageBucketApi.swift
@@ -9,7 +9,7 @@ import Foundation
 public class StorageBucketApi: StorageApi {
   /// Retrieves the details of all Storage buckets within an existing product.
   public func listBuckets() async throws -> [Bucket] {
-    try await execute(Request(path: "/bucket", method: "GET"))
+    try await execute(Request(path: "/bucket", method: .get))
       .decoded(decoder: configuration.decoder)
   }
 
@@ -17,7 +17,7 @@ public class StorageBucketApi: StorageApi {
   /// - Parameters:
   ///   - id: The unique identifier of the bucket you would like to retrieve.
   public func getBucket(id: String) async throws -> Bucket {
-    try await execute(Request(path: "/bucket/\(id)", method: "GET"))
+    try await execute(Request(path: "/bucket/\(id)", method: .get))
       .decoded(decoder: configuration.decoder)
   }
 
@@ -36,7 +36,7 @@ public class StorageBucketApi: StorageApi {
     try await execute(
       Request(
         path: "/bucket",
-        method: "POST",
+        method: .post,
         body: configuration.encoder.encode(
           BucketParameters(
             id: id,
@@ -57,7 +57,7 @@ public class StorageBucketApi: StorageApi {
     try await execute(
       Request(
         path: "/bucket/\(id)",
-        method: "PUT",
+        method: .put,
         body: configuration.encoder.encode(
           BucketParameters(
             id: id,
@@ -75,7 +75,7 @@ public class StorageBucketApi: StorageApi {
   /// - Parameters:
   ///   - id: The unique identifier of the bucket you would like to empty.
   public func emptyBucket(id: String) async throws {
-    try await execute(Request(path: "/bucket/\(id)/empty", method: "POST"))
+    try await execute(Request(path: "/bucket/\(id)/empty", method: .post))
   }
 
   /// Deletes an existing bucket. A bucket can't be deleted with existing objects inside it.
@@ -83,6 +83,6 @@ public class StorageBucketApi: StorageApi {
   /// - Parameters:
   ///   - id: The unique identifier of the bucket you would like to delete.
   public func deleteBucket(id: String) async throws {
-    try await execute(Request(path: "/bucket/\(id)", method: "DELETE"))
+    try await execute(Request(path: "/bucket/\(id)", method: .delete))
   }
 }

--- a/Sources/Storage/StorageFileApi.swift
+++ b/Sources/Storage/StorageFileApi.swift
@@ -33,7 +33,7 @@ public class StorageFileApi: StorageApi {
   }
 
   func uploadOrUpdate(
-    method: String,
+    method: Request.Method,
     path: String,
     file: Data,
     fileOptions: FileOptions
@@ -74,7 +74,7 @@ public class StorageFileApi: StorageApi {
   public func upload(path: String, file: File, fileOptions: FileOptions = FileOptions())
     async throws -> String
   {
-    try await uploadOrUpdate(method: "POST", path: path, file: file.data, fileOptions: fileOptions)
+    try await uploadOrUpdate(method: .post, path: path, file: file.data, fileOptions: fileOptions)
   }
 
   /// Replaces an existing file at the specified path with a new one.
@@ -87,7 +87,7 @@ public class StorageFileApi: StorageApi {
   public func update(path: String, file: File, fileOptions: FileOptions = FileOptions())
     async throws -> String
   {
-    try await uploadOrUpdate(method: "PUT", path: path, file: file.data, fileOptions: fileOptions)
+    try await uploadOrUpdate(method: .put, path: path, file: file.data, fileOptions: fileOptions)
   }
 
   /// Moves an existing file, optionally renaming it at the same time.
@@ -99,7 +99,7 @@ public class StorageFileApi: StorageApi {
     try await execute(
       Request(
         path: "/object/move",
-        method: "POST",
+        method: .post,
         body: configuration.encoder.encode(
           [
             "bucketId": bucketId,
@@ -121,7 +121,7 @@ public class StorageFileApi: StorageApi {
     try await execute(
       Request(
         path: "/object/copy",
-        method: "POST",
+        method: .post,
         body: configuration.encoder.encode(
           [
             "bucketId": bucketId,
@@ -163,7 +163,7 @@ public class StorageFileApi: StorageApi {
     let response = try await execute(
       Request(
         path: "/object/sign/\(bucketId)/\(path)",
-        method: "POST",
+        method: .post,
         body: encoder.encode(
           Body(expiresIn: expiresIn, transform: transform)
         )
@@ -203,7 +203,7 @@ public class StorageFileApi: StorageApi {
     try await execute(
       Request(
         path: "/object/\(bucketId)",
-        method: "DELETE",
+        method: .delete,
         body: configuration.encoder.encode(["prefixes": paths])
       )
     )
@@ -224,7 +224,7 @@ public class StorageFileApi: StorageApi {
     return try await execute(
       Request(
         path: "/object/list/\(bucketId)",
-        method: "POST",
+        method: .post,
         body: configuration.encoder.encode(options)
       )
     )
@@ -244,7 +244,7 @@ public class StorageFileApi: StorageApi {
     let renderPath = options != nil ? "render/image/authenticated" : "object"
 
     return try await execute(
-      Request(path: "/\(renderPath)/\(bucketId)/\(path)", method: "GET", query: queryItems)
+      Request(path: "/\(renderPath)/\(bucketId)/\(path)", method: .get, query: queryItems)
     )
     .data
   }

--- a/Sources/_Helpers/Request.swift
+++ b/Sources/_Helpers/Request.swift
@@ -3,13 +3,25 @@ import Foundation
 @_spi(Internal)
 public struct Request {
   public var path: String
-  public var method: String
+  public var method: Method
   public var query: [URLQueryItem]
   public var headers: [String: String]
   public var body: Data?
 
+  public enum Method: String {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+    case patch = "PATCH"
+    case head = "HEAD"
+  }
+
   public init(
-    path: String, method: String, query: [URLQueryItem] = [], headers: [String: String] = [:],
+    path: String,
+    method: Method,
+    query: [URLQueryItem] = [],
+    headers: [String: String] = [:],
     body: Data? = nil
   ) {
     self.path = path
@@ -26,7 +38,8 @@ public struct Request {
         throw URLError(.badURL)
       }
 
-      components.queryItems = query
+      let currentQueryItems = components.queryItems ?? []
+      components.percentEncodedQuery = percentEncodedQuery(currentQueryItems + query)
 
       if let newURL = components.url {
         url = newURL
@@ -36,7 +49,7 @@ public struct Request {
     }
 
     var request = URLRequest(url: url)
-    request.httpMethod = method
+    request.httpMethod = method.rawValue
 
     if body != nil, headers["Content-Type"] == nil {
       request.setValue("application/json", forHTTPHeaderField: "Content-Type")
@@ -50,6 +63,47 @@ public struct Request {
 
     return request
   }
+
+  private func percentEncodedQuery(_ query: [URLQueryItem]) -> String {
+    query.compactMap { query in
+      if let value = query.value {
+        return (query.name, value)
+      }
+      return nil
+    }
+    .map { name, value -> String in
+      let escapedName = name
+        .addingPercentEncoding(withAllowedCharacters: .postgrestURLQueryAllowed) ?? name
+      let escapedValue = value
+        .addingPercentEncoding(withAllowedCharacters: .postgrestURLQueryAllowed) ?? value
+      return "\(escapedName)=\(escapedValue)"
+    }
+    .joined(separator: "&")
+  }
+}
+
+extension CharacterSet {
+  /// Creates a CharacterSet from RFC 3986 allowed characters.
+  ///
+  /// RFC 3986 states that the following characters are "reserved" characters.
+  ///
+  /// - General Delimiters: ":", "#", "[", "]", "@", "?", "/"
+  /// - Sub-Delimiters: "!", "$", "&", "'", "(", ")", "*", "+", ",", ";", "="
+  ///
+  /// In RFC 3986 - Section 3.4, it states that the "?" and "/" characters should not be escaped to
+  /// allow
+  /// query strings to include a URL. Therefore, all "reserved" characters with the exception of "?"
+  /// and "/"
+  /// should be percent-escaped in the query string.
+  static let postgrestURLQueryAllowed: CharacterSet = {
+    let generalDelimitersToEncode =
+      ":#[]@" // does not include "?" or "/" due to RFC 3986 - Section 3.4
+    let subDelimitersToEncode = "!$&'()*+,;="
+    let encodableDelimiters =
+      CharacterSet(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
+
+    return CharacterSet.urlQueryAllowed.subtracting(encodableDelimiters)
+  }()
 }
 
 @_spi(Internal)

--- a/Sources/_Helpers/Request.swift
+++ b/Sources/_Helpers/Request.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@_spi(Internal)
 public struct HTTPClient {
   public typealias FetchHandler = @Sendable (URLRequest) async throws -> (Data, URLResponse)
 
@@ -9,7 +10,6 @@ public struct HTTPClient {
     self.fetchHandler = fetchHandler
   }
 
-  @_spi(Internal)
   public func fetch(_ request: Request, baseURL: URL) async throws -> Response {
     let urlRequest = try request.urlRequest(withBaseURL: baseURL)
     let (data, response) = try await fetchHandler(urlRequest)

--- a/Sources/_Helpers/Request.swift
+++ b/Sources/_Helpers/Request.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @_spi(Internal)
-public struct HTTPClient {
+public struct HTTPClient: Sendable {
   public typealias FetchHandler = @Sendable (URLRequest) async throws -> (Data, URLResponse)
 
   let fetchHandler: FetchHandler
@@ -23,14 +23,14 @@ public struct HTTPClient {
 }
 
 @_spi(Internal)
-public struct Request {
+public struct Request: Sendable {
   public var path: String
   public var method: Method
   public var query: [URLQueryItem]
   public var headers: [String: String]
   public var body: Data?
 
-  public enum Method: String {
+  public enum Method: String, Sendable {
     case get = "GET"
     case post = "POST"
     case put = "PUT"
@@ -129,7 +129,7 @@ extension CharacterSet {
 }
 
 @_spi(Internal)
-public struct Response {
+public struct Response: Sendable {
   public let data: Data
   public let response: HTTPURLResponse
 

--- a/Supabase.xctestplan
+++ b/Supabase.xctestplan
@@ -1,0 +1,66 @@
+{
+  "configurations" : [
+    {
+      "id" : "5F632059-FF26-463E-B598-A1902519AB3F",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "FunctionsTests",
+        "name" : "FunctionsTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "GoTrueTests",
+        "name" : "GoTrueTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "PostgRESTIntegrationTests",
+        "name" : "PostgRESTIntegrationTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "PostgRESTTests",
+        "name" : "PostgRESTTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "RealtimeTests",
+        "name" : "RealtimeTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "StorageTests",
+        "name" : "StorageTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "SupabaseTests",
+        "name" : "SupabaseTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/GoTrueTests/GoTrueClientTests.swift
+++ b/Tests/GoTrueTests/GoTrueClientTests.swift
@@ -57,7 +57,7 @@ final class GoTrueClientTests: XCTestCase {
       }
     )
 
-    api = APIClient()
+    api = APIClient(http: HTTPClient(fetchHandler: configuration.fetch))
 
     let sut = GoTrueClient(
       configuration: configuration,

--- a/Tests/GoTrueTests/Mocks/Mocks.swift
+++ b/Tests/GoTrueTests/Mocks/Mocks.swift
@@ -57,7 +57,7 @@ extension Dependencies {
   static let mock = Dependencies(
     configuration: GoTrueClient.Configuration(url: clientURL),
     sessionManager: .mock,
-    api: APIClient(),
+    api: APIClient(http: HTTPClient(fetchHandler: unimplemented("HTTPClient.fetch"))),
     eventEmitter: .mock,
     sessionStorage: .mock,
     sessionRefresher: .mock,

--- a/Tests/GoTrueTests/RequestsTests.swift
+++ b/Tests/GoTrueTests/RequestsTests.swift
@@ -356,8 +356,7 @@ final class RequestsTests: XCTestCase {
       }
     )
 
-    // TODO: Inject a mocked APIClient
-    let api = APIClient()
+    let api = APIClient(http: HTTPClient(fetchHandler: configuration.fetch))
 
     return GoTrueClient(
       configuration: configuration,

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -26,13 +26,13 @@ final class BuildURLRequestTests: XCTestCase {
       url: url,
       schema: nil,
       headers: ["X-Client-Info": "postgrest-swift/x.y.z"],
-      fetch: { @MainActor request in
-        runningTestCase.withValue { runningTestCase in
-          guard let runningTestCase else {
-            XCTFail("execute called without a runningTestCase set.")
-            return (Data(), URLResponse())
-          }
+      fetch: { request in
+        guard let runningTestCase = runningTestCase.value else {
+          XCTFail("execute called without a runningTestCase set.")
+          return (Data(), URLResponse())
+        }
 
+        await MainActor.run { [runningTestCase] in
           assertSnapshot(
             matching: request,
             as: .curl,
@@ -40,9 +40,9 @@ final class BuildURLRequestTests: XCTestCase {
             record: runningTestCase.record,
             testName: "testBuildRequest()"
           )
-
-          return (Data(), URLResponse())
         }
+
+        return (Data(), URLResponse())
       }
     )
 

--- a/supabase-swift.xcworkspace/contents.xcworkspacedata
+++ b/supabase-swift.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,7 @@
    <FileRef
       location = "container:Examples/Examples.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Supabase.xctestplan">
+   </FileRef>
 </Workspace>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the current behavior?

Some sub-packages implement their logic for building a URLRequest.

## What is the new behavior?

All sub-packages, GoTrue, Supabase, and PostgREST, share the same logic for transforming a `Request` into a `URLRequest` for later execution.