### PR TITLE
feat: add filter to RPC call

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/PostgREST.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/PostgREST.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "PostgREST"
+               BuildableName = "PostgREST"
+               BlueprintName = "PostgREST"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "PostgREST"
+            BuildableName = "PostgREST"
+            BlueprintName = "PostgREST"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -454,6 +454,10 @@ public struct AuthMFAEnrollResponse: Decodable, Hashable, Sendable {
 public struct MFAChallengeParams: Encodable, Hashable {
   /// ID of the factor to be challenged. Returned in ``GoTrueMFA/enroll(params:)``.
   public let factorId: String
+
+  public init(factorId: String) {
+    self.factorId = factorId
+  }
 }
 
 public struct MFAVerifyParams: Encodable, Hashable {
@@ -465,6 +469,12 @@ public struct MFAVerifyParams: Encodable, Hashable {
 
   /// Verification code provided by the user.
   public let code: String
+
+  public init(factorId: String, challengeId: String, code: String) {
+    self.factorId = factorId
+    self.challengeId = challengeId
+    self.code = code
+  }
 }
 
 public struct MFAUnenrollParams: Encodable, Hashable, Sendable {

--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -112,13 +112,13 @@ public actor PostgrestClient {
   ///   - params: The parameters to pass to the function call.
   ///   - count: Count algorithm to use to count rows returned by the function.
   ///             Only applicable for set-returning functions.
-  /// - Returns: A PostgrestTransformBuilder instance.
+  /// - Returns: A PostgrestFilterBuilder instance.
   /// - Throws: An error if the function call fails.
   public func rpc(
     _ fn: String,
     params: some Encodable,
     count: CountOption? = nil
-  ) throws -> PostgrestTransformBuilder {
+  ) throws -> PostgrestFilterBuilder {
     try PostgrestRpcBuilder(
       configuration: configuration,
       request: Request(path: "/rpc/\(fn)", method: .post, headers: configuration.headers)
@@ -130,12 +130,12 @@ public actor PostgrestClient {
   ///   - fn: The function name to call.
   ///   - count: Count algorithm to use to count rows returned by the function.
   ///            Only applicable for set-returning functions.
-  /// - Returns: A PostgrestTransformBuilder instance.
+  /// - Returns: A PostgrestFilterBuilder instance.
   /// - Throws: An error if the function call fails.
   public func rpc(
     _ fn: String,
     count: CountOption? = nil
-  ) throws -> PostgrestTransformBuilder {
+  ) throws -> PostgrestFilterBuilder {
     try rpc(fn, params: NoParams(), count: count)
   }
 }

--- a/Sources/PostgREST/PostgrestRpcBuilder.swift
+++ b/Sources/PostgREST/PostgrestRpcBuilder.swift
@@ -16,7 +16,7 @@ public final class PostgrestRpcBuilder: PostgrestBuilder {
     params: some Encodable,
     head: Bool = false,
     count: CountOption? = nil
-  ) throws -> PostgrestTransformBuilder {
+  ) throws -> PostgrestFilterBuilder {
     // TODO: Support `HEAD` method
     // https://github.com/supabase/postgrest-js/blob/master/src/lib/PostgrestRpcBuilder.ts#L38
     assert(head == false, "HEAD is not currently supported yet.")
@@ -38,6 +38,6 @@ public final class PostgrestRpcBuilder: PostgrestBuilder {
       }
     }
 
-    return PostgrestTransformBuilder(self)
+    return PostgrestFilterBuilder(self)
   }
 }

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -62,6 +62,9 @@ final class BuildURLRequestTests: XCTestCase {
       TestCase(name: "call rpc without parameter") { client in
         try await client.rpc("test_fcn")
       },
+      TestCase(name: "call rpc with filter") { client in
+        try await client.rpc("test_fcn").eq("id", value: 1)
+      },
       TestCase(name: "test all filters and count") { client in
         var query = await client.from("todos").select()
 

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.call-rpc-with-filter.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.call-rpc-with-filter.txt
@@ -1,0 +1,6 @@
+curl \
+	--request POST \
+	--header "Accept: application/json" \
+	--header "Content-Type: application/json" \
+	--header "X-Client-Info: postgrest-swift/x.y.z" \
+	"https://example.supabase.co/rpc/test_fcn?id=eq.1"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature, close #149
Documentation update: https://github.com/supabase/supabase/pull/18682/commits/1e7fe57af75e7be96a5df7e43ed64b013a7c8f23

## What is the current behavior?

Can't call a filter such as `eq` after `rpc`.

## What is the new behavior?

Make `rpc` method returns a `PostgrestFilterBuilder`, so all filters can be appended to the call.