### PR TITLE
fix(functions): functions overrides headers

### DIFF
--- a/Sources/Functions/Types.swift
+++ b/Sources/Functions/Types.swift
@@ -34,23 +34,23 @@ public struct FunctionInvokeOptions {
   ///   - headers: Headers to be included in the function invocation. (Default: empty dictionary)
   ///   - body: The body data to be sent with the function invocation. (Default: nil)
   public init(method: Method? = nil, headers: [String: String] = [:], body: some Encodable) {
-    var headers = headers
+    var defaultHeaders = headers
 
     switch body {
     case let string as String:
-      headers["Content-Type"] = "text/plain"
+      defaultHeaders["Content-Type"] = "text/plain"
       self.body = string.data(using: .utf8)
     case let data as Data:
-      headers["Content-Type"] = "application/octet-stream"
+      defaultHeaders["Content-Type"] = "application/octet-stream"
       self.body = data
     default:
       // default, assume this is JSON
-      headers["Content-Type"] = "application/json"
+      defaultHeaders["Content-Type"] = "application/json"
       self.body = try? JSONEncoder().encode(body)
     }
 
     self.method = method
-    self.headers = headers
+    self.headers = defaultHeaders.merging(headers) { _, new in new }
   }
 
   /// Initializes the `FunctionInvokeOptions` structure.

--- a/Tests/FunctionsTests/FunctionInvokeOptionsTests.swift
+++ b/Tests/FunctionsTests/FunctionInvokeOptionsTests.swift
@@ -3,24 +3,35 @@ import XCTest
 @testable import Functions
 
 final class FunctionInvokeOptionsTests: XCTestCase {
-  func testStringBody() {
+  func test_initWithStringBody() {
     let options = FunctionInvokeOptions(body: "string value")
     XCTAssertEqual(options.headers["Content-Type"], "text/plain")
     XCTAssertNotNil(options.body)
   }
 
-  func testDataBody() {
+  func test_initWithDataBody() {
     let options = FunctionInvokeOptions(body: "binary value".data(using: .utf8)!)
     XCTAssertEqual(options.headers["Content-Type"], "application/octet-stream")
     XCTAssertNotNil(options.body)
   }
 
-  func testEncodableBody() {
+  func test_initWithEncodableBody() {
     struct Body: Encodable {
       let value: String
     }
     let options = FunctionInvokeOptions(body: Body(value: "value"))
     XCTAssertEqual(options.headers["Content-Type"], "application/json")
+    XCTAssertNotNil(options.body)
+  }
+
+  func test_initWithCustomContentType() {
+    let boundary = "Boundary-\(UUID().uuidString)"
+    let contentType = "multipart/form-data; boundary=\(boundary)"
+    let options = FunctionInvokeOptions(
+      headers: ["Content-Type": contentType],
+      body: "binary value".data(using: .utf8)!
+    )
+    XCTAssertEqual(options.headers["Content-Type"], contentType)
     XCTAssertNotNil(options.body)
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`FunctionInvokeOptions` overrides the specified `Content-Type` header value to `application/octet-stream` when body is of type `Data`.

## What is the new behavior?

If a custom `content-type` is passed to the initializer, keep it.

## Additional context

Same fix as https://github.com/supabase-community/functions-swift/pull/6, but in monorepo
