### PR TITLE
Correct typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Supabase client for swift. Mirrors the design of [supabase-js](https://github.co
 
 > [!WARNING]  
 > This library is a work in progress, you can choose to use the last available version 0.3.0, or use the `main` branch that contains the next 1.0 release.
-> 1.0 will have several breacking changes, so I don't recommend you start a project using 0.3, just use the `main` branch from now, as the API is pretty much stable at this stage.
+> 1.0 will have several breaking changes, so I don't recommend you start a project using 0.3, just use the `main` branch from now, as the API is pretty much stable at this stage.
 
 ## Usage
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Quick update to the README.md file so that it says "breaking" instead of "breacking"

## What is the current behavior?

The readme says "breacking"

## What is the new behavior?

The readme says "breaking"