### PR TITLE
Fix error decoding

### DIFF
--- a/Sources/GoTrue/GoTrueError.swift
+++ b/Sources/GoTrue/GoTrueError.swift
@@ -14,14 +14,6 @@ public enum GoTrueError: LocalizedError, Sendable {
     public var code: Int?
     public var error: String?
     public var errorDescription: String?
-
-    private enum CodingKeys: String, CodingKey {
-      case message
-      case msg
-      case code
-      case error
-      case errorDescription = "error_description"
-    }
   }
 
   public enum PKCEFailureReason: Sendable {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a small bug when decoding API errors in the GoTrue package.

## What is the current behavior?

The current `keyDecodingStrategy` used by the GoTrue package already decodes from snake case to camel case, however coding keys were explicitly set, leading to an error message with missing information. I came across this when trying out Supabase for the first time and receiving an error about an unconfirmed email address, it was impossible to debug this without running a network proxy and inspecting the response.

## What is the new behavior?

Removes codingKeys from `GoTrueError.APIError` as this is covered already by `keyDecodingStrategy` and was causing issues.
