### PR TITLE
feat(gotrue): add scope to signOut

### DIFF
--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -576,6 +576,15 @@ public struct AuthMFAGetAuthenticatorAssuranceLevelResponse: Decodable, Hashable
   public let currentAuthenticationMethods: [AMREntry]
 }
 
+public enum SignOutScope: String {
+    /// All sessions by this account will be signed out.
+    case global
+    /// Only this session will be signed out.
+    case local
+    /// All other sessions except the current one will be signed out. When using `others`, there is no `AuthChangeEvent.signedOut` event fired on the current session.
+    case others
+}
+
 // MARK: - Encodable & Decodable
 
 private let dateFormatterWithFractionalSeconds = { () -> ISO8601DateFormatter in

--- a/Tests/GoTrueTests/RequestsTests.swift
+++ b/Tests/GoTrueTests/RequestsTests.swift
@@ -249,6 +249,30 @@ final class RequestsTests: XCTestCase {
       }
     }
   }
+  
+  func testSignOutWithLocalScope() async {
+    let sut = makeSUT()
+    await withDependencies {
+      $0.sessionManager.session = { @Sendable _ in .validSession }
+      $0.eventEmitter = .noop
+    } operation: {
+      await assert {
+        try await sut.signOut(scope: .local)
+      }
+    }
+  }
+  
+  func testSignOutWithOthersScope() async {
+    let sut = makeSUT()
+    await withDependencies {
+      $0.sessionManager.session = { @Sendable _ in .validSession }
+      $0.eventEmitter = .noop
+    } operation: {
+      await assert {
+        try await sut.signOut(scope: .others)
+      }
+    }
+  }
 
   func testVerifyOTPUsingEmail() async {
     let sut = makeSUT()

--- a/Tests/GoTrueTests/__Snapshots__/RequestsTests/testSignOutWithLocalScope.1.txt
+++ b/Tests/GoTrueTests/__Snapshots__/RequestsTests/testSignOutWithLocalScope.1.txt
@@ -3,4 +3,4 @@ curl \
 	--header "Authorization: Bearer accesstoken" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
 	--header "apikey: dummy.api.key" \
-	"http://localhost:54321/auth/v1/logout?scope=global"
+	"http://localhost:54321/auth/v1/logout?scope=local"

--- a/Tests/GoTrueTests/__Snapshots__/RequestsTests/testSignOutWithOthersScope.1.txt
+++ b/Tests/GoTrueTests/__Snapshots__/RequestsTests/testSignOutWithOthersScope.1.txt
@@ -3,4 +3,4 @@ curl \
 	--header "Authorization: Bearer accesstoken" \
 	--header "X-Client-Info: gotrue-swift/x.y.z" \
 	--header "apikey: dummy.api.key" \
-	"http://localhost:54321/auth/v1/logout?scope=global"
+	"http://localhost:54321/auth/v1/logout?scope=others"


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds the `scope` parameter to the signOut method which can be used to control which sessions should be signed out of the account.

## What is the current behavior?
Calling `signOut()` with no scope specified signs out all sessions, revoking all refresh tokens for the user.
This behaviour is maintained with the default scope parameter `.global`.

## What is the new behavior?
Adds scope parameter to `signOut()`.

## Additional context
https://github.com/supabase/gotrue/pull/1112
https://github.com/supabase/gotrue-js/pull/713
https://github.com/supabase/supabase-flutter/pull/530
