### PR TITLE
fix(gotrue): ignore 401 and 404 errors on sign out

### DIFF
--- a/Examples/Examples.xcodeproj/xcshareddata/xcschemes/UserManagement.xcscheme
+++ b/Examples/Examples.xcodeproj/xcshareddata/xcschemes/UserManagement.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "79FEFFAB2B07873600D36347"
+               BuildableName = "UserManagement.app"
+               BlueprintName = "UserManagement"
+               ReferencedContainer = "container:Examples.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "79FEFFAB2B07873600D36347"
+            BuildableName = "UserManagement.app"
+            BlueprintName = "UserManagement"
+            ReferencedContainer = "container:Examples.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "79FEFFAB2B07873600D36347"
+            BuildableName = "UserManagement.app"
+            BlueprintName = "UserManagement"
+            ReferencedContainer = "container:Examples.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -605,7 +605,11 @@ public actor GoTrueClient {
     } catch {
       // ignore 404s since user might not exist anymore
       // ignore 401s since an invalid or expired JWT should sign out the current session
-      if case let GoTrueError.api(apiError) = error, apiError.code == 404 || apiError.code == 401 {
+      let ignoredCodes = Set([404, 401])
+
+      if case let GoTrueError.api(apiError) = error, let code = apiError.code,
+         !ignoredCodes.contains(code)
+      {
         throw error
       }
     }

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -591,10 +591,10 @@ public actor GoTrueClient {
   /// If using ``SignOutScope/others`` scope, no ``AuthChangeEvent/signedOut`` event is fired.
   /// - Parameter scope: Specifies which sessions should be logged out.
   public func signOut(scope: SignOutScope = .global) async throws {
-    // Make sure we have a valid session.
-    _ = try await sessionManager.session()
-
     do {
+      // Make sure we have a valid session.
+      _ = try await sessionManager.session()
+
       try await api.authorizedExecute(
         .init(
           path: "/logout",

--- a/Sources/GoTrue/GoTrueClient.swift
+++ b/Sources/GoTrue/GoTrueClient.swift
@@ -130,7 +130,7 @@ public actor GoTrueClient {
   /// - Parameters:
   ///   - configuration: The client configuration.
   public init(configuration: Configuration) {
-    let api = APIClient(http: HTTPClient(fetchHandler: configuration.fetch))
+    let api = APIClient.live(http: HTTPClient(fetchHandler: configuration.fetch))
 
     self.init(
       configuration: configuration,
@@ -347,7 +347,7 @@ public actor GoTrueClient {
 
     let (codeChallenge, codeChallengeMethod) = prepareForPKCE()
 
-    try await api.execute(
+    _ = try await api.execute(
       .init(
         path: "/otp",
         method: .post,
@@ -382,7 +382,7 @@ public actor GoTrueClient {
     captchaToken: String? = nil
   ) async throws {
     await sessionManager.remove()
-    try await api.execute(
+    _ = try await api.execute(
       .init(
         path: "/otp",
         method: .post,
@@ -741,7 +741,7 @@ public actor GoTrueClient {
   ) async throws {
     let (codeChallenge, codeChallengeMethod) = prepareForPKCE()
 
-    try await api.execute(
+    _ = try await api.execute(
       .init(
         path: "/recover",
         method: .post,

--- a/Sources/GoTrue/Internal/APIClient.swift
+++ b/Sources/GoTrue/Internal/APIClient.swift
@@ -1,46 +1,45 @@
 import Foundation
 @_spi(Internal) import _Helpers
 
-actor APIClient {
-  private var configuration: GoTrueClient.Configuration {
-    Dependencies.current.value!.configuration
+struct APIClient: Sendable {
+  var execute: @Sendable (_ request: Request) async throws -> Response
+}
+
+extension APIClient {
+  static func live(http: HTTPClient) -> Self {
+    var configuration: GoTrueClient.Configuration {
+      Dependencies.current.value!.configuration
+    }
+
+    return APIClient(
+      execute: { request in
+        var request = request
+        request.headers.merge(configuration.headers) { r, _ in r }
+
+        let response = try await http.fetch(request, baseURL: configuration.url)
+
+        guard (200 ..< 300).contains(response.statusCode) else {
+          let apiError = try configuration.decoder.decode(
+            GoTrueError.APIError.self,
+            from: response.data
+          )
+          throw GoTrueError.api(apiError)
+        }
+
+        return response
+      }
+    )
   }
+}
 
-  private var sessionManager: SessionManager {
-    Dependencies.current.value!.sessionManager
-  }
-
-  let http: HTTPClient
-
-  init(http: HTTPClient) {
-    self.http = http
-  }
-
+extension APIClient {
   @discardableResult
   func authorizedExecute(_ request: Request) async throws -> Response {
-    let session = try await sessionManager.session()
+    let session = try await Dependencies.current.value!.sessionManager.session()
 
     var request = request
     request.headers["Authorization"] = "Bearer \(session.accessToken)"
 
     return try await execute(request)
-  }
-
-  @discardableResult
-  func execute(_ request: Request) async throws -> Response {
-    var request = request
-    request.headers.merge(configuration.headers) { r, _ in r }
-
-    let response = try await http.fetch(request, baseURL: configuration.url)
-
-    guard (200 ..< 300).contains(response.statusCode) else {
-      let apiError = try configuration.decoder.decode(
-        GoTrueError.APIError.self,
-        from: response.data
-      )
-      throw GoTrueError.api(apiError)
-    }
-
-    return response
   }
 }

--- a/Sources/GoTrue/Types.swift
+++ b/Sources/GoTrue/Types.swift
@@ -576,13 +576,15 @@ public struct AuthMFAGetAuthenticatorAssuranceLevelResponse: Decodable, Hashable
   public let currentAuthenticationMethods: [AMREntry]
 }
 
-public enum SignOutScope: String {
-    /// All sessions by this account will be signed out.
-    case global
-    /// Only this session will be signed out.
-    case local
-    /// All other sessions except the current one will be signed out. When using `others`, there is no `AuthChangeEvent.signedOut` event fired on the current session.
-    case others
+public enum SignOutScope: String, Sendable {
+  /// All sessions by this account will be signed out.
+  case global
+  /// Only this session will be signed out.
+  case local
+  /// All other sessions except the current one will be signed out. When using
+  /// ``SignOutScope/others``, there is no ``AuthChangeEvent/signedOut`` event fired on the current
+  /// session.
+  case others
 }
 
 // MARK: - Encodable & Decodable

--- a/Tests/GoTrueTests/Mocks/Mocks.swift
+++ b/Tests/GoTrueTests/Mocks/Mocks.swift
@@ -5,6 +5,7 @@
 //  Created by Guilherme Souza on 27/10/23.
 //
 
+import ConcurrencyExtras
 import Foundation
 import XCTestDynamicOverlay
 @_spi(Internal) import _Helpers
@@ -15,24 +16,24 @@ let clientURL = URL(string: "http://localhost:54321/auth/v1")!
 
 extension CodeVerifierStorage {
   static let mock = Self(
-    getCodeVerifier: unimplemented("getCodeVerifier"),
-    storeCodeVerifier: unimplemented("storeCodeVerifier"),
-    deleteCodeVerifier: unimplemented("deleteCodeVerifier")
+    getCodeVerifier: unimplemented("CodeVerifierStorage.getCodeVerifier"),
+    storeCodeVerifier: unimplemented("CodeVerifierStorage.storeCodeVerifier"),
+    deleteCodeVerifier: unimplemented("CodeVerifierStorage.deleteCodeVerifier")
   )
 }
 
 extension SessionManager {
   static let mock = Self(
-    session: unimplemented("session"),
-    update: unimplemented("update"),
-    remove: unimplemented("remove")
+    session: unimplemented("SessionManager.session"),
+    update: unimplemented("SessionManager.update"),
+    remove: unimplemented("SessionManager.remove")
   )
 }
 
 extension EventEmitter {
   static let mock = Self(
-    attachListener: unimplemented("attachListener"),
-    emit: unimplemented("emit")
+    attachListener: unimplemented("EventEmitter.attachListener"),
+    emit: unimplemented("EventEmitter.emit")
   )
 
   static let noop = Self(
@@ -43,14 +44,24 @@ extension EventEmitter {
 
 extension SessionStorage {
   static let mock = Self(
-    getSession: unimplemented("getSession"),
-    storeSession: unimplemented("storeSession"),
-    deleteSession: unimplemented("deleteSession")
+    getSession: unimplemented("SessionStorage.getSession"),
+    storeSession: unimplemented("SessionStorage.storeSession"),
+    deleteSession: unimplemented("SessionStorage.deleteSession")
   )
+
+  static var inMemory: Self {
+    let session = LockIsolated(StoredSession?.none)
+
+    return Self(
+      getSession: { session.value },
+      storeSession: { session.setValue($0) },
+      deleteSession: { session.setValue(nil) }
+    )
+  }
 }
 
 extension SessionRefresher {
-  static let mock = Self(refreshSession: unimplemented("refreshSession"))
+  static let mock = Self(refreshSession: unimplemented("SessionRefresher.refreshSession"))
 }
 
 extension Dependencies {
@@ -66,12 +77,12 @@ extension Dependencies {
 }
 
 func withDependencies(
-  _ mutation: (inout Dependencies) -> Void,
+  _ mutation: (inout Dependencies) throws -> Void,
   operation: () async throws -> Void
 ) async rethrows {
   let current = Dependencies.current.value ?? .mock
   var copy = current
-  mutation(&copy)
+  try mutation(&copy)
   Dependencies.current.withValue { [copy] in $0 = copy }
   defer { Dependencies.current.setValue(current) }
   try await operation()

--- a/Tests/GoTrueTests/Mocks/Mocks.swift
+++ b/Tests/GoTrueTests/Mocks/Mocks.swift
@@ -64,11 +64,15 @@ extension SessionRefresher {
   static let mock = Self(refreshSession: unimplemented("SessionRefresher.refreshSession"))
 }
 
+extension APIClient {
+  static let mock = APIClient(execute: unimplemented("APIClient.execute"))
+}
+
 extension Dependencies {
   static let mock = Dependencies(
     configuration: GoTrueClient.Configuration(url: clientURL),
     sessionManager: .mock,
-    api: APIClient(http: HTTPClient(fetchHandler: unimplemented("HTTPClient.fetch"))),
+    api: .mock,
     eventEmitter: .mock,
     sessionStorage: .mock,
     sessionRefresher: .mock,

--- a/Tests/GoTrueTests/RequestsTests.swift
+++ b/Tests/GoTrueTests/RequestsTests.swift
@@ -249,7 +249,7 @@ final class RequestsTests: XCTestCase {
       }
     }
   }
-  
+
   func testSignOutWithLocalScope() async {
     let sut = makeSUT()
     await withDependencies {
@@ -261,7 +261,7 @@ final class RequestsTests: XCTestCase {
       }
     }
   }
-  
+
   func testSignOutWithOthersScope() async {
     let sut = makeSUT()
     await withDependencies {

--- a/Tests/GoTrueTests/RequestsTests.swift
+++ b/Tests/GoTrueTests/RequestsTests.swift
@@ -242,6 +242,7 @@ final class RequestsTests: XCTestCase {
     let sut = makeSUT()
     await withDependencies {
       $0.sessionManager.session = { @Sendable _ in .validSession }
+      $0.sessionManager.remove = {}
       $0.eventEmitter = .noop
     } operation: {
       await assert {
@@ -254,6 +255,7 @@ final class RequestsTests: XCTestCase {
     let sut = makeSUT()
     await withDependencies {
       $0.sessionManager.session = { @Sendable _ in .validSession }
+      $0.sessionManager.remove = {}
       $0.eventEmitter = .noop
     } operation: {
       await assert {
@@ -380,7 +382,7 @@ final class RequestsTests: XCTestCase {
       }
     )
 
-    let api = APIClient(http: HTTPClient(fetchHandler: configuration.fetch))
+    let api = APIClient.live(http: HTTPClient(fetchHandler: configuration.fetch))
 
     return GoTrueClient(
       configuration: configuration,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix https://github.com/supabase-community/supabase-swift/issues/176

## What is the current behavior?

When the user is deleted through Admin, the call to `signOut` on the client fails and the user doesn't log out locally because it returns a 404.

## What is the new behavior?

Ignore 404 and 401 errors when signing out, which will ensure to always log out the user locally.