### PR TITLE
feat(postgrest): set coder in SupabaseClientOptions

### DIFF
--- a/Sources/Supabase/SupabaseClient.swift
+++ b/Sources/Supabase/SupabaseClient.swift
@@ -27,7 +27,9 @@ public final class SupabaseClient: @unchecked Sendable {
     url: databaseURL,
     schema: options.db.schema,
     headers: defaultHeaders,
-    fetch: fetchWithAuth
+    fetch: fetchWithAuth,
+    encoder: options.db.encoder,
+    decoder: options.db.decoder
   )
 
   /// Supabase Storage allows you to manage user-generated content, such as photos or videos.

--- a/Sources/Supabase/Types.swift
+++ b/Sources/Supabase/Types.swift
@@ -10,9 +10,13 @@ public struct SupabaseClientOptions: Sendable {
     /// The Postgres schema which your tables belong to. Must be on the list of exposed schemas in
     /// Supabase. Defaults to `public`.
     public let schema: String
+    public let encoder: JSONEncoder
+    public let decoder: JSONDecoder
 
-    public init(schema: String = "public") {
+    public init(schema: String = "public", encoder: JSONEncoder = .postgrest, decoder: JSONDecoder = .postgrest) {
       self.schema = schema
+      self.encoder = encoder
+      self.decoder = decoder
     }
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

When using `SupabaseClient`, developers cannot set the `encoder` and `decoder` used by PostgrestClient.

## What is the new behavior?

Add encoder and decoder parameters to SupabaseClientOptions.DatabaseOptions, this allows developers to pass in their own encoder and decoder

## Additional context

Add any other context or screenshots.
