### PR TITLE
feat(auth): add resend method

### DIFF
--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -586,3 +586,35 @@ public enum SignOutScope: String, Sendable {
   /// session.
   case others
 }
+
+public enum ResendEmailType: String, Hashable, Sendable, Encodable {
+  case signup
+  case emailChange = "email_change"
+}
+
+struct ResendEmailParams: Encodable {
+  let type: ResendEmailType
+  let email: String
+  let gotrueMetaSecurity: AuthMetaSecurity?
+}
+
+public enum ResendMobileType: String, Hashable, Sendable, Encodable {
+  case sms
+  case phoneChange = "phone_change"
+}
+
+struct ResendMobileParams: Encodable {
+  let type: ResendMobileType
+  let phone: String
+  let gotrueMetaSecurity: AuthMetaSecurity?
+}
+
+public struct ResendMobileResponse: Decodable, Hashable, Sendable {
+  /// Unique ID of the message as reported by the SMS sending provider. Useful for tracking
+  /// deliverability problems.
+  public let messageId: String?
+
+  public init(messageId: String?) {
+    self.messageId = messageId
+  }
+}

--- a/Tests/AuthTests/RequestsTests.swift
+++ b/Tests/AuthTests/RequestsTests.swift
@@ -344,6 +344,31 @@ final class RequestsTests: XCTestCase {
     }
   }
 
+  func testResendEmail() async {
+    let sut = makeSUT()
+
+    await assert {
+      try await sut.resend(
+        email: "example@mail.com",
+        type: .emailChange,
+        emailRedirectTo: URL(string: "https://supabase.com"),
+        captchaToken: "captcha-token"
+      )
+    }
+  }
+
+  func testResendPhone() async {
+    let sut = makeSUT()
+
+    await assert {
+      try await sut.resend(
+        phone: "+1 202-918-2132",
+        type: .phoneChange,
+        captchaToken: "captcha-token"
+      )
+    }
+  }
+
   private func assert(_ block: () async throws -> Void) async {
     do {
       try await block()

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testResendEmail.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testResendEmail.1.txt
@@ -1,0 +1,7 @@
+curl \
+	--request POST \
+	--header "Content-Type: application/json" \
+	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "apikey: dummy.api.key" \
+	--data "{\"email\":\"example@mail.com\",\"gotrue_meta_security\":{\"captcha_token\":\"captcha-token\"},\"type\":\"email_change\"}" \
+	"http://localhost:54321/auth/v1/resend?redirect_to=https://supabase.com"

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testResendPhone.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testResendPhone.1.txt
@@ -1,0 +1,7 @@
+curl \
+	--request POST \
+	--header "Content-Type: application/json" \
+	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--header "apikey: dummy.api.key" \
+	--data "{\"gotrue_meta_security\":{\"captcha_token\":\"captcha-token\"},\"phone\":\"+1 202-918-2132\",\"type\":\"phone_change\"}" \
+	"http://localhost:54321/auth/v1/resend"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Close #108 

## What is the current behavior?

User isn't able to resend email and mobile OTP.

## What is the new behavior?

Adds 2 methods:

```swift
func resend(
    email: String,
    type: ResendEmailType,
    emailRedirectTo: URL? = nil,
    captchaToken: String? = nil
) async throws
```

and 

```swift
func resend(
    phone: String,
    type: ResendMobileType,
    captchaToken: String? = nil
) async throws -> ResendMobileResponse
```

## Additional context

Add any other context or screenshots.
