### PR TITLE
feat(postgrest): allow switching schema

### DIFF
--- a/Sources/PostgREST/PostgrestClient.swift
+++ b/Sources/PostgREST/PostgrestClient.swift
@@ -134,4 +134,14 @@ public actor PostgrestClient {
   ) throws -> PostgrestFilterBuilder {
     try rpc(fn, params: NoParams(), count: count)
   }
+
+  /// Select a schema to query or perform an function (rpc) call.
+  ///
+  /// The schema needs to be on the list of exposed schemas inside Supabase.
+  /// - Parameter schema: The schema to query.
+  public func schema(_ schema: String) -> PostgrestClient {
+    var configuration = configuration
+    configuration.schema = schema
+    return PostgrestClient(configuration: configuration)
+  }
 }

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -106,6 +106,11 @@ final class BuildURLRequestTests: XCTestCase {
           .gt("received_at", value: "2023-03-23T15:50:30.511743+00:00")
           .order("received_at")
       },
+      TestCase(name: "query non-default schema") { client in
+        await client.schema("storage")
+          .from("objects")
+          .select()
+      }
     ]
 
     for testCase in testCases {

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.query-non-default-schema.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.query-non-default-schema.txt
@@ -1,0 +1,6 @@
+curl \
+	--header "Accept: application/json" \
+	--header "Accept-Profile: storage" \
+	--header "Content-Type: application/json" \
+	--header "X-Client-Info: postgrest-swift/x.y.z" \
+	"https://example.supabase.co/objects?select=*"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

PostgrestClient isn't able to dynamically switch the schema.

## What is the new behavior?

Add `schema(_:)` method for PostgrestClient, that returns a new client instance configured with the provided schema.
