### PR TITLE
feat: auto-connect socket on channel subscription

### DIFF
--- a/Sources/Realtime/RealtimeChannel.swift
+++ b/Sources/Realtime/RealtimeChannel.swift
@@ -349,6 +349,10 @@ public class RealtimeChannel {
     timeout: TimeInterval? = nil,
     callback: ((RealtimeSubscribeStates, Error?) -> Void)? = nil
   ) -> RealtimeChannel {
+    if socket?.isConnected == false {
+      socket?.connect()
+    }
+
     guard !joinedOnce else {
       fatalError(
         "tried to join multiple times. 'join' "


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

The user needs to manually call `realtime.connect()`

## What is the new behavior?

When calling `subscribe` on a channel, it automatically connects the socket if it isn't connected.
