### PR TITLE
Update GoogleSignIn.swift

### DIFF
--- a/Examples/Examples/Auth/GoogleSignIn.swift
+++ b/Examples/Examples/Auth/GoogleSignIn.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import AuthenticationServices
 
 struct GoogleSignIn: View {
   @Environment(\.webAuthenticationSession) var webAuthenticationSession


### PR DESCRIPTION
Add AuthenticationServices import when using webAuthenticationSession. Xcode throws up errors if it's not imported.

## What kind of change does this PR introduce?

docs update

