### PR TITLE
feat: add AdminAPI and deleteUser method

### DIFF
--- a/Examples/UserManagement/AuthView.swift
+++ b/Examples/UserManagement/AuthView.swift
@@ -8,6 +8,7 @@
 import Supabase
 import SwiftUI
 
+@MainActor
 struct AuthView: View {
   @State var email = ""
   @State var isLoading = false

--- a/Examples/UserManagement/ProfileView.swift
+++ b/Examples/UserManagement/ProfileView.swift
@@ -9,6 +9,7 @@ import PhotosUI
 import Supabase
 import SwiftUI
 
+@MainActor
 struct ProfileView: View {
   @State var username = ""
   @State var fullName = ""
@@ -69,6 +70,10 @@ struct ProfileView: View {
           if isLoading {
             ProgressView()
           }
+
+          Button("Delete account", role: .destructive) {
+            deleteAccountButtonTapped()
+          }
         }
       }
       .onMac { $0.padding() }
@@ -82,7 +87,7 @@ struct ProfileView: View {
           }
         }
       })
-      .onChange(of: imageSelection) { newValue in
+      .onChange(of: imageSelection) { _, newValue in
         guard let newValue else { return }
         loadTransferable(from: newValue)
       }
@@ -173,6 +178,20 @@ struct ProfileView: View {
       )
 
     return filePath
+  }
+
+  private func deleteAccountButtonTapped() {
+    Task {
+      do {
+        let currentUserId = try await supabase.auth.session.user.id
+        try await supabase.auth.admin.deleteUser(
+          id: currentUserId.uuidString,
+          shouldSoftDelete: true
+        )
+      } catch {
+        debugPrint(error)
+      }
+    }
   }
 }
 

--- a/Examples/UserManagement/Supabase.swift
+++ b/Examples/UserManagement/Supabase.swift
@@ -10,8 +10,8 @@ import OSLog
 import Supabase
 
 let supabase = SupabaseClient(
-  supabaseURL: URL(string: "https://PROJECT_ID.supabase.co")!,
-  supabaseKey: "YOUR_SUPABASE_ANON_KEY",
+  supabaseURL: URL(string: "http://127.0.0.1:54321")!,
+  supabaseKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU",
   options: .init(
     global: .init(logger: AppLogger())
   )

--- a/Examples/UserManagement/supabase/.gitignore
+++ b/Examples/UserManagement/supabase/.gitignore
@@ -1,0 +1,4 @@
+# Supabase
+.branches
+.temp
+.env

--- a/Examples/UserManagement/supabase/config.toml
+++ b/Examples/UserManagement/supabase/config.toml
@@ -1,0 +1,159 @@
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "UserManagement"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. public and storage are always included.
+schemas = ["public", "storage", "graphql_public"]
+# Extra schemas to add to the search_path of every request. public is always included.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 15
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv6)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000", "io.supabase.user-management://*"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = true
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }} ."
+
+# Use pre-defined map of phone number to OTP for testing.
+[auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+[auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+
+[analytics]
+enabled = false
+port = 54327
+vector_port = 54328
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"

--- a/Examples/UserManagement/supabase/migrations/20240125111924_init.sql
+++ b/Examples/UserManagement/supabase/migrations/20240125111924_init.sql
@@ -1,0 +1,64 @@
+-- Create a table for public profiles
+create table profiles(
+  id uuid references auth.users not null primary key,
+  updated_at timestamp with time zone,
+  username text unique,
+  full_name text,
+  avatar_url text,
+  website text,
+  constraint username_length check (char_length(username) >= 3)
+);
+
+-- Set up Row Level Security (RLS)
+-- See https://supabase.com/docs/guides/auth/row-level-security for more details.
+alter table profiles enable row level security;
+
+create policy "Public profiles are viewable by everyone." on profiles
+  for select
+    using (true);
+
+create policy "Users can insert their own profile." on profiles
+  for insert
+    with check (auth.uid() = id);
+
+create policy "Users can update own profile." on profiles
+  for update
+    using (auth.uid() = id);
+
+-- This trigger automatically creates a profile entry when a new user signs up via Supabase Auth.
+-- See https://supabase.com/docs/guides/auth/managing-user-data#using-triggers for more details.
+create function public.handle_new_user()
+  returns trigger
+  as $$
+begin
+  insert into public.profiles(id, full_name, avatar_url)
+    values(new.id, new.raw_user_meta_data ->> 'full_name', new.raw_user_meta_data ->> 'avatar_url');
+  return new;
+end;
+$$
+language plpgsql
+security definer;
+
+create trigger on_auth_user_created
+  after insert on auth.users for each row
+  execute procedure public.handle_new_user();
+
+-- Set up Storage!
+insert into storage.buckets(id, name)
+  values ('avatars', 'avatars');
+
+-- Set up access controls for storage.
+-- See https://supabase.com/docs/guides/storage/security/access-control#policy-examples for more details.
+create policy "Avatar images are publicly accessible." on storage.objects
+  for select
+    using (bucket_id = 'avatars');
+
+create policy "Anyone can upload an avatar." on storage.objects
+  for insert
+    with check (bucket_id = 'avatars');
+
+create policy "Anyone can update their own avatar." on storage.objects
+  for update
+    using (auth.uid() = owner)
+    with check (bucket_id = 'avatars');
+

--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -1,0 +1,40 @@
+//
+//  AuthAdmin.swift
+//
+//
+//  Created by Guilherme Souza on 25/01/24.
+//
+
+import Foundation
+@_spi(Internal) import _Helpers
+
+public actor AuthAdmin {
+  private var configuration: AuthClient.Configuration {
+    Dependencies.current.value!.configuration
+  }
+
+  private var api: APIClient {
+    Dependencies.current.value!.api
+  }
+
+  public init() {}
+
+  /// Delete a user. Requires `service_role` key.
+  /// - Parameter id: The id of the user you want to delete.
+  /// - Parameter shouldSoftDelete: If true, then the user will be soft-deleted (setting
+  /// `deleted_at` to the current timestamp and disabling their account while preserving their data)
+  /// from the auth schema.
+  ///
+  /// - Warning: Never expose your `service_role` key on the client.
+  @discardableResult
+  public func deleteUser(id: String, shouldSoftDelete: Bool = true) async throws -> User {
+    try await api.execute(
+      Request(
+        path: "/admin/users/\(id)",
+        method: .delete,
+        body: configuration.encoder.encode(DeleteUserRequest(shouldSoftDelete: shouldSoftDelete))
+      )
+    )
+    .decoded(decoder: configuration.decoder)
+  }
+}

--- a/Sources/Auth/AuthAdmin.swift
+++ b/Sources/Auth/AuthAdmin.swift
@@ -17,8 +17,6 @@ public actor AuthAdmin {
     Dependencies.current.value!.api
   }
 
-  public init() {}
-
   /// Delete a user. Requires `service_role` key.
   /// - Parameter id: The id of the user you want to delete.
   /// - Parameter shouldSoftDelete: If true, then the user will be soft-deleted (setting
@@ -26,15 +24,13 @@ public actor AuthAdmin {
   /// from the auth schema.
   ///
   /// - Warning: Never expose your `service_role` key on the client.
-  @discardableResult
-  public func deleteUser(id: String, shouldSoftDelete: Bool = true) async throws -> User {
-    try await api.execute(
+  public func deleteUser(id: String, shouldSoftDelete: Bool = false) async throws {
+    _ = try await api.execute(
       Request(
         path: "/admin/users/\(id)",
         method: .delete,
         body: configuration.encoder.encode(DeleteUserRequest(shouldSoftDelete: shouldSoftDelete))
       )
     )
-    .decoded(decoder: configuration.decoder)
   }
 }

--- a/Sources/Auth/AuthClient.swift
+++ b/Sources/Auth/AuthClient.swift
@@ -95,6 +95,11 @@ public actor AuthClient {
   /// Namespace for accessing multi-factor authentication API.
   public let mfa: AuthMFA
 
+  /// Namespace for the GoTrue admin methods.
+  /// - Warning: This methods requires `service_role` key, be careful to never expose `service_role`
+  /// key in the client.
+  public let admin: AuthAdmin
+
   /// Initializes a AuthClient with optional parameters.
   ///
   /// - Parameters:
@@ -162,6 +167,7 @@ public actor AuthClient {
     logger: SupabaseLogger?
   ) {
     mfa = AuthMFA()
+    admin = AuthAdmin()
 
     Dependencies.current.setValue(
       Dependencies(

--- a/Sources/Auth/Internal/APIClient.swift
+++ b/Sources/Auth/Internal/APIClient.swift
@@ -26,6 +26,9 @@ extension APIClient {
             throw AuthError.api(apiError)
           }
 
+          /// There are some GoTrue endpoints that can return a `PostgrestError`, for example the
+          /// ``AuthAdmin/deleteUser(id:shouldSoftDelete:)`` that could return an error in case the
+          /// user is referenced by other schemas.
           let postgrestError = try configuration.decoder.decode(
             PostgrestError.self,
             from: response.data

--- a/Sources/Auth/Internal/APIClient.swift
+++ b/Sources/Auth/Internal/APIClient.swift
@@ -19,11 +19,18 @@ extension APIClient {
         let response = try await http.fetch(request, baseURL: configuration.url)
 
         guard (200 ..< 300).contains(response.statusCode) else {
-          let apiError = try configuration.decoder.decode(
+          if let apiError = try? configuration.decoder.decode(
             AuthError.APIError.self,
             from: response.data
+          ) {
+            throw AuthError.api(apiError)
+          }
+
+          let postgrestError = try configuration.decoder.decode(
+            PostgrestError.self,
+            from: response.data
           )
-          throw AuthError.api(apiError)
+          throw postgrestError
         }
 
         return response

--- a/Sources/Auth/Types.swift
+++ b/Sources/Auth/Types.swift
@@ -646,3 +646,7 @@ public struct WeakPassword: Codable, Hashable, Sendable {
   /// `pwned`.
   public let reasons: [String]
 }
+
+struct DeleteUserRequest: Encodable {
+  let shouldSoftDelete: Bool
+}

--- a/Sources/PostgREST/Types.swift
+++ b/Sources/PostgREST/Types.swift
@@ -4,26 +4,6 @@ import Foundation
   import FoundationNetworking
 #endif
 
-public struct PostgrestError: Error, Codable, Sendable {
-  public let details: String?
-  public let hint: String?
-  public let code: String?
-  public let message: String
-
-  public init(details: String? = nil, hint: String? = nil, code: String? = nil, message: String) {
-    self.hint = hint
-    self.details = details
-    self.code = code
-    self.message = message
-  }
-}
-
-extension PostgrestError: LocalizedError {
-  public var errorDescription: String? {
-    message
-  }
-}
-
 public struct PostgrestResponse<T: Sendable>: Sendable {
   public let data: Data
   public let response: HTTPURLResponse

--- a/Sources/Storage/TransformOptions.swift
+++ b/Sources/Storage/TransformOptions.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct TransformOptions: Encodable {
+public struct TransformOptions: Encodable, Sendable {
   public var width: Int?
   public var height: Int?
   public var resize: String?

--- a/Sources/Storage/Types.swift
+++ b/Sources/Storage/Types.swift
@@ -37,7 +37,7 @@ public struct SortBy: Encodable {
   }
 }
 
-public struct FileOptions {
+public struct FileOptions: Sendable {
   /// The number of seconds the asset is cached in the browser and in the Supabase CDN. This is set
   /// in the `Cache-Control: max-age=<seconds>` header. Defaults to 3600 seconds.
   public var cacheControl: String

--- a/Sources/_Helpers/Request.swift
+++ b/Sources/_Helpers/Request.swift
@@ -19,13 +19,24 @@ public struct HTTPClient: Sendable {
   public func fetch(_ request: Request, baseURL: URL) async throws -> Response {
     let id = UUID().uuidString
     let urlRequest = try request.urlRequest(withBaseURL: baseURL)
-    logger?.verbose("Request [\(id)]: \(urlRequest)")
+    logger?
+      .verbose(
+        "Request [\(id)]: \(urlRequest.httpMethod ?? "") \(urlRequest.url?.absoluteString.removingPercentEncoding ?? "")"
+      )
     let (data, response) = try await fetchHandler(urlRequest)
-    logger?.verbose("Response [\(id)]: \(response)")
 
     guard let httpResponse = response as? HTTPURLResponse else {
+      logger?
+        .error(
+          "Response [\(id)]: Expected a \(HTTPURLResponse.self) instance, but got a \(type(of: response))."
+        )
       throw URLError(.badServerResponse)
     }
+
+    logger?
+      .verbose(
+        "Response [\(id)]: Status code: \(httpResponse.statusCode) Content-Length: \(httpResponse.expectedContentLength)"
+      )
 
     return Response(data: data, response: httpResponse)
   }

--- a/Sources/_Helpers/SharedModels/PostgrestError.swift
+++ b/Sources/_Helpers/SharedModels/PostgrestError.swift
@@ -1,0 +1,33 @@
+//
+//  PostgrestError.swift
+//
+//
+//  Created by Guilherme Souza on 27/01/24.
+//
+
+import Foundation
+
+public struct PostgrestError: Error, Codable, Sendable {
+  public let detail: String?
+  public let hint: String?
+  public let code: String?
+  public let message: String
+
+  public init(
+    detail: String? = nil,
+    hint: String? = nil,
+    code: String? = nil,
+    message: String
+  ) {
+    self.hint = hint
+    self.detail = detail
+    self.code = code
+    self.message = message
+  }
+}
+
+extension PostgrestError: LocalizedError {
+  public var errorDescription: String? {
+    message
+  }
+}

--- a/Tests/AuthTests/RequestsTests.swift
+++ b/Tests/AuthTests/RequestsTests.swift
@@ -381,6 +381,15 @@ final class RequestsTests: XCTestCase {
     }
   }
 
+  func testDeleteUser() async {
+    let sut = makeSUT()
+
+    let id = "E621E1F8-C36C-495A-93FC-0C247A3E6E5F"
+    await assert {
+      try await sut.admin.deleteUser(id: id)
+    }
+  }
+
   private func assert(_ block: () async throws -> Void) async {
     do {
       try await block()

--- a/Tests/AuthTests/__Snapshots__/RequestsTests/testDeleteUser.1.txt
+++ b/Tests/AuthTests/__Snapshots__/RequestsTests/testDeleteUser.1.txt
@@ -1,0 +1,7 @@
+curl \
+	--request DELETE \
+	--header "Apikey: dummy.api.key" \
+	--header "Content-Type: application/json" \
+	--header "X-Client-Info: gotrue-swift/x.y.z" \
+	--data "{\"should_soft_delete\":false}" \
+	"http://localhost:54321/auth/v1/admin/users/E621E1F8-C36C-495A-93FC-0C247A3E6E5F"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Close #192 

## What is the current behavior?

Missing implementation of Admin APIs

## What is the new behavior?

- Add `AuthAdmin` actor that will contain all admin endpoints
- Add `deleteUser` method for deleting a user using the `service_role` key

## Additional context

`service_role` key should never be exposed on client code, it will be up to the library user to make sure `service_role` key is safe.
