### PR TITLE
Improve EventEmitter implementation

### DIFF
--- a/Tests/AuthTests/Mocks/MockEventEmitter.swift
+++ b/Tests/AuthTests/Mocks/MockEventEmitter.swift
@@ -1,0 +1,25 @@
+//
+//  MockEventEmitter.swift
+//
+//
+//  Created by Guilherme Souza on 15/02/24.
+//
+
+@testable import Auth
+import ConcurrencyExtras
+import Foundation
+
+final class MockEventEmitter: EventEmitter {
+  let emitedParams: LockIsolated<[(AuthChangeEvent, Session?, AuthStateChangeListenerHandle?)]> =
+    .init([])
+
+  override func emit(
+    _ event: AuthChangeEvent,
+    session: Session?,
+    handle: AuthStateChangeListenerHandle? = nil
+  ) {
+    emitedParams.withValue {
+      $0.append((event, session, handle))
+    }
+  }
+}

--- a/Tests/AuthTests/Mocks/MockEventEmitter.swift
+++ b/Tests/AuthTests/Mocks/MockEventEmitter.swift
@@ -10,16 +10,16 @@ import ConcurrencyExtras
 import Foundation
 
 final class MockEventEmitter: EventEmitter {
-  let emitedParams: LockIsolated<[(AuthChangeEvent, Session?, AuthStateChangeListenerHandle?)]> =
-    .init([])
+  let emitReceivedParams: LockIsolated<[(AuthChangeEvent, Session?)]> = .init([])
 
   override func emit(
     _ event: AuthChangeEvent,
     session: Session?,
     handle: AuthStateChangeListenerHandle? = nil
   ) {
-    emitedParams.withValue {
-      $0.append((event, session, handle))
+    emitReceivedParams.withValue {
+      $0.append((event, session))
     }
+    super.emit(event, session: session, handle: handle)
   }
 }

--- a/Tests/AuthTests/Mocks/Mocks.swift
+++ b/Tests/AuthTests/Mocks/Mocks.swift
@@ -30,18 +30,6 @@ extension SessionManager {
   )
 }
 
-extension EventEmitter {
-  static let mock = Self(
-    attachListener: unimplemented("EventEmitter.attachListener"),
-    emit: unimplemented("EventEmitter.emit")
-  )
-
-  static let noop = Self(
-    attachListener: { (UUID(), AsyncStream.makeStream().stream) },
-    emit: { _, _, _ in }
-  )
-}
-
 extension SessionStorage {
   static let mock = Self(
     getSession: unimplemented("SessionStorage.getSession"),
@@ -108,10 +96,14 @@ extension Dependencies {
   }()
 
   static let mock = Dependencies(
-    configuration: AuthClient.Configuration(url: clientURL, localStorage: Self.localStorage),
+    configuration: AuthClient.Configuration(
+      url: clientURL,
+      localStorage: Self.localStorage,
+      logger: nil
+    ),
     sessionManager: .mock,
     api: .mock,
-    eventEmitter: .mock,
+    eventEmitter: EventEmitter(),
     sessionStorage: .mock,
     sessionRefresher: .mock,
     codeVerifierStorage: .mock,

--- a/Tests/AuthTests/RequestsTests.swift
+++ b/Tests/AuthTests/RequestsTests.swift
@@ -179,7 +179,6 @@ final class RequestsTests: XCTestCase {
         $0.sessionManager.update = { _ in }
         $0.sessionStorage.storeSession = { _ in }
         $0.codeVerifierStorage.getCodeVerifier = { nil }
-        $0.eventEmitter = .live
         $0.currentDate = { currentDate }
       } operation: {
         let url = URL(
@@ -255,7 +254,6 @@ final class RequestsTests: XCTestCase {
     await withDependencies {
       $0.sessionManager.session = { @Sendable _ in .validSession }
       $0.sessionManager.remove = {}
-      $0.eventEmitter = .noop
     } operation: {
       await assert {
         try await sut.signOut()
@@ -268,7 +266,6 @@ final class RequestsTests: XCTestCase {
     await withDependencies {
       $0.sessionManager.session = { @Sendable _ in .validSession }
       $0.sessionManager.remove = {}
-      $0.eventEmitter = .noop
     } operation: {
       await assert {
         try await sut.signOut(scope: .local)
@@ -280,7 +277,6 @@ final class RequestsTests: XCTestCase {
     let sut = makeSUT()
     await withDependencies {
       $0.sessionManager.session = { @Sendable _ in .validSession }
-      $0.eventEmitter = .noop
     } operation: {
       await assert {
         try await sut.signOut(scope: .others)
@@ -438,7 +434,7 @@ final class RequestsTests: XCTestCase {
       sessionManager: .mock,
       codeVerifierStorage: .mock,
       api: api,
-      eventEmitter: .mock,
+      eventEmitter: EventEmitter(),
       sessionStorage: .mock,
       logger: nil
     )


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix / refactor

## What is the current behavior?

Listening for auth change events is implemented only by Swift Async/Await, this has some inconsistencies, such as not emitting the `initialSession`.

## What is the new behavior?

Refactor implementation to use closure based listeners, and make async/await API use closure based internally