### PR TITLE
feat: Add optional "referencedTable" parameter to OR PostGREST filter

### DIFF
--- a/Sources/PostgREST/PostgrestFilterBuilder.swift
+++ b/Sources/PostgREST/PostgrestFilterBuilder.swift
@@ -22,9 +22,10 @@ public class PostgrestFilterBuilder: PostgrestTransformBuilder {
     return self
   }
 
-  public func or(_ filters: URLQueryRepresentable) -> PostgrestFilterBuilder {
+  public func or(_ filters: URLQueryRepresentable, referencedTable: String? = nil) -> PostgrestFilterBuilder {
+    let key = referencedTable.map { "\($0).or" } ?? "or"
     mutableState.withValue {
-      $0.request.query.append(URLQueryItem(name: "or", value: "(\(filters.queryValue.queryValue))"))
+      $0.request.query.append(URLQueryItem(name: key, value: "(\(filters.queryValue.queryValue))"))
     }
     return self
   }

--- a/Tests/PostgRESTTests/BuildURLRequestTests.swift
+++ b/Tests/PostgRESTTests/BuildURLRequestTests.swift
@@ -123,6 +123,11 @@ final class BuildURLRequestTests: XCTestCase {
           .select()
           .contains("name", value: ["is:online", "faction:red"])
       },
+      TestCase(name: "test or filter with referenced table") { client in
+        await client.from("users")
+          .select("*, messages(*)")
+          .or("public.eq.true,recipient_id.eq.1", referencedTable: "messages")
+      },
       TestCase(name: "test upsert not ignoring duplicates") { client in
         try await client.from("users")
           .upsert(User(email: "johndoe@supabase.io"))

--- a/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.test-or-filter-with-referenced-table.txt
+++ b/Tests/PostgRESTTests/__Snapshots__/BuildURLRequestTests/testBuildRequest.test-or-filter-with-referenced-table.txt
@@ -1,0 +1,5 @@
+curl \
+	--header "Accept: application/json" \
+	--header "Content-Type: application/json" \
+	--header "X-Client-Info: postgrest-swift/x.y.z" \
+	"https://example.supabase.co/users?messages.or=(public.eq.true,recipient_id.eq.1)&select=*,messages(*)"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

When using the or filter, the columns have to be in the table referenced in the "from" clause

## What is the new behavior?

Users can now specify an optional "referencedTable" parameter to the or filter, allowing the or to reference other tables besides the main table in the "from" clause.

## Additional context

![image](https://github.com/supabase-community/supabase-swift/assets/8967127/02ba8b19-02ce-4381-a040-07dc5ebfbfa7)