### PR TITLE
fix(realtime): web socket message listener doesn't stop

### DIFF
--- a/Sources/Realtime/V2/WebSocketClient.swift
+++ b/Sources/Realtime/V2/WebSocketClient.swift
@@ -38,8 +38,9 @@ final class WebSocket: NSObject, URLSessionWebSocketDelegate, WebSocketClient, @
   private let logger: (any SupabaseLogger)?
 
   struct MutableState {
-    var task: URLSessionWebSocketTask?
     var continuation: AsyncStream<ConnectionStatus>.Continuation?
+    var task: URLSessionWebSocketTask?
+    var stream: SocketStream?
   }
 
   let mutableState = LockIsolated(MutableState())
@@ -56,8 +57,10 @@ final class WebSocket: NSObject, URLSessionWebSocketDelegate, WebSocketClient, @
   func connect() -> AsyncStream<ConnectionStatus> {
     mutableState.withValue { state in
       let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
-      state.task = session.webSocketTask(with: realtimeURL)
-      state.task?.resume()
+      let task = session.webSocketTask(with: realtimeURL)
+      state.task = task
+      state.stream = SocketStream(task: task)
+      task.resume()
 
       let (stream, continuation) = AsyncStream<ConnectionStatus>.makeStream()
       state.continuation = continuation
@@ -67,41 +70,40 @@ final class WebSocket: NSObject, URLSessionWebSocketDelegate, WebSocketClient, @
 
   func disconnect(closeCode: URLSessionWebSocketTask.CloseCode) {
     mutableState.withValue { state in
-      state.task?.cancel(with: closeCode, reason: nil)
+      state.stream?.cancel(with: closeCode)
     }
   }
 
   func receive() -> AsyncThrowingStream<RealtimeMessageV2, any Error> {
-    let (stream, continuation) = AsyncThrowingStream<RealtimeMessageV2, any Error>.makeStream()
-
-    Task {
-      while let message = try await mutableState.task?.receive() {
-        do {
-          switch message {
-          case let .string(stringMessage):
-            logger?.verbose("Received message: \(stringMessage)")
-
-            guard let data = stringMessage.data(using: .utf8) else {
-              throw RealtimeError("Expected a UTF8 encoded message.")
-            }
-
-            let message = try JSONDecoder().decode(RealtimeMessageV2.self, from: data)
-            continuation.yield(message)
-
-          case .data:
-            fallthrough
-          default:
-            throw RealtimeError("Unsupported message type.")
-          }
-        } catch {
-          continuation.finish(throwing: error)
-        }
+    mutableState.withValue { mutableState in
+      guard let stream = mutableState.stream else {
+        return .finished(
+          throwing: RealtimeError(
+            "receive() called before connect(). Make sure to call `connect()` before calling `receive()`."
+          )
+        )
       }
 
-      continuation.finish()
-    }
+      return stream.map { message in
+        switch message {
+        case let .string(stringMessage):
+          self.logger?.verbose("Received message: \(stringMessage)")
 
-    return stream
+          guard let data = stringMessage.data(using: .utf8) else {
+            throw RealtimeError("Expected a UTF8 encoded message.")
+          }
+
+          let message = try JSONDecoder().decode(RealtimeMessageV2.self, from: data)
+          return message
+
+        case .data:
+          fallthrough
+        default:
+          throw RealtimeError("Unsupported message type.")
+        }
+      }
+      .eraseToThrowingStream()
+    }
   }
 
   func send(_ message: RealtimeMessageV2) async throws {
@@ -142,5 +144,56 @@ final class WebSocket: NSObject, URLSessionWebSocketDelegate, WebSocketClient, @
     didCompleteWithError error: (any Error)?
   ) {
     mutableState.continuation?.yield(.error(error))
+  }
+}
+
+typealias WebSocketStream = AsyncThrowingStream<URLSessionWebSocketTask.Message, any Error>
+
+final class SocketStream: AsyncSequence {
+  typealias AsyncIterator = WebSocketStream.Iterator
+  typealias Element = URLSessionWebSocketTask.Message
+
+  private var continuation: WebSocketStream.Continuation?
+  private let task: URLSessionWebSocketTask
+
+  private lazy var stream: WebSocketStream = WebSocketStream { continuation in
+    self.continuation = continuation
+    waitForNextValue()
+  }
+
+  private func waitForNextValue() {
+    guard task.closeCode == .invalid else {
+      continuation?.finish()
+      return
+    }
+
+    task.receive { [weak self] result in
+      guard let continuation = self?.continuation else { return }
+
+      do {
+        let message = try result.get()
+        continuation.yield(message)
+        self?.waitForNextValue()
+      } catch {
+        continuation.finish(throwing: error)
+      }
+    }
+  }
+
+  init(task: URLSessionWebSocketTask) {
+    self.task = task
+  }
+
+  deinit {
+    continuation?.finish()
+  }
+
+  func makeAsyncIterator() -> WebSocketStream.Iterator {
+    stream.makeAsyncIterator()
+  }
+
+  func cancel(with closeCode: URLSessionWebSocketTask.CloseCode = .goingAway) {
+    task.cancel(with: closeCode, reason: nil)
+    continuation?.finish()
   }
 }

--- a/Sources/Realtime/V2/WebSocketClient.swift
+++ b/Sources/Realtime/V2/WebSocketClient.swift
@@ -39,7 +39,6 @@ final class WebSocket: NSObject, URLSessionWebSocketDelegate, WebSocketClient, @
 
   struct MutableState {
     var continuation: AsyncStream<ConnectionStatus>.Continuation?
-    var task: URLSessionWebSocketTask?
     var stream: SocketStream?
   }
 
@@ -58,7 +57,6 @@ final class WebSocket: NSObject, URLSessionWebSocketDelegate, WebSocketClient, @
     mutableState.withValue { state in
       let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
       let task = session.webSocketTask(with: realtimeURL)
-      state.task = task
       state.stream = SocketStream(task: task)
       task.resume()
 
@@ -111,7 +109,7 @@ final class WebSocket: NSObject, URLSessionWebSocketDelegate, WebSocketClient, @
     let string = String(decoding: data, as: UTF8.self)
 
     logger?.verbose("Sending message: \(string)")
-    try await mutableState.task?.send(.string(string))
+    try await mutableState.stream?.send(.string(string))
   }
 
   // MARK: - URLSessionWebSocketDelegate
@@ -149,26 +147,42 @@ final class WebSocket: NSObject, URLSessionWebSocketDelegate, WebSocketClient, @
 
 typealias WebSocketStream = AsyncThrowingStream<URLSessionWebSocketTask.Message, any Error>
 
-final class SocketStream: AsyncSequence {
+final class SocketStream: AsyncSequence, Sendable {
   typealias AsyncIterator = WebSocketStream.Iterator
   typealias Element = URLSessionWebSocketTask.Message
 
-  private var continuation: WebSocketStream.Continuation?
-  private let task: URLSessionWebSocketTask
+  struct MutableState {
+    var continuation: WebSocketStream.Continuation?
+    var stream: WebSocketStream?
+  }
 
-  private lazy var stream: WebSocketStream = WebSocketStream { continuation in
-    self.continuation = continuation
-    waitForNextValue()
+  private let task: URLSessionWebSocketTask
+  private let mutableState = LockIsolated(MutableState())
+
+  private func makeStreamIfNeeded() -> WebSocketStream {
+    mutableState.withValue { state in
+      if let stream = state.stream {
+        return stream
+      }
+
+      let stream = WebSocketStream { continuation in
+        state.continuation = continuation
+        waitForNextValue()
+      }
+
+      state.stream = stream
+      return stream
+    }
   }
 
   private func waitForNextValue() {
     guard task.closeCode == .invalid else {
-      continuation?.finish()
+      mutableState.continuation?.finish()
       return
     }
 
     task.receive { [weak self] result in
-      guard let continuation = self?.continuation else { return }
+      guard let continuation = self?.mutableState.continuation else { return }
 
       do {
         let message = try result.get()
@@ -185,15 +199,19 @@ final class SocketStream: AsyncSequence {
   }
 
   deinit {
-    continuation?.finish()
+    mutableState.continuation?.finish()
   }
 
   func makeAsyncIterator() -> WebSocketStream.Iterator {
-    stream.makeAsyncIterator()
+    makeStreamIfNeeded().makeAsyncIterator()
   }
 
   func cancel(with closeCode: URLSessionWebSocketTask.CloseCode = .goingAway) {
     task.cancel(with: closeCode, reason: nil)
-    continuation?.finish()
+    mutableState.continuation?.finish()
+  }
+
+  func send(_ message: URLSessionWebSocketTask.Message) async throws {
+    try await task.send(message)
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When the WebSocket is closed by the client, the listener for messages doesn't stop.

## What is the new behavior?

By wrapping the web socket task in a SocketStream class that exposes a custom cancel method, we make sure to finish the stream when canceling the socket connection on the client side.

## Additional context

There are some caveats when wrapping WebSocket in async/await, but thanks to https://www.donnywals.com/iterating-over-web-socket-messages-with-async-await-in-swift/ this PR fixes it.